### PR TITLE
Tag input tags should show a box-shadow

### DIFF
--- a/packages/core/src/_overwrites.scss
+++ b/packages/core/src/_overwrites.scss
@@ -81,3 +81,14 @@
 .#{$ns}-input-ghost {
   font-size: 14px;
 }
+
+.#{$ns}-tag-input .#{$ns}-tag {
+  overflow-wrap: break-word;
+  background: $dark-gray5;
+  border-radius: 24px;
+  padding-left: 8px;
+  box-shadow: $custom-shadow;
+  color: white;
+  font-size: 16px;
+  font-weight: normal;
+}


### PR DESCRIPTION
https://graphext.atlassian.net/browse/GRAPH-1006

![captura de pantalla 2018-09-14 a las 10 47 22](https://user-images.githubusercontent.com/24293766/45540060-c7bcf280-b80b-11e8-88b7-ce418a2cb804.png)

As there is no scss variables for that I have had to update styles in overwrites.scss.
See https://github.com/graphext/blueprint/blob/graphext/packages/core/src/components/tag-input/_tag-input.scss#L52