### PR TITLE
Override tag input and popover styles to get desired dropdown result

### DIFF
--- a/packages/core/src/_overrides.scss
+++ b/packages/core/src/_overrides.scss
@@ -87,8 +87,11 @@
 
 // Tag Input
 
-.#{$ns}-input-ghost {
-  font-size: 14px;
+.#{$ns}-tag-input {
+  .#{$ns}-input-ghost {
+    width: 100%;
+    font-size: 14px;
+  }
 }
 
 .#{$ns}-tag-input .#{$ns}-tag {

--- a/packages/select/src/components/select/_overrides.scss
+++ b/packages/select/src/components/select/_overrides.scss
@@ -10,7 +10,7 @@
 }
 
 .#{$ns}-popover-target {
-  max-width: 100%;
+  width: 100%;
 }
 
 .#{$ns}-popover-wrapper {
@@ -18,9 +18,9 @@
 }
 
 .#{$ns}-multi-select-popover .#{$ns}-menu {
-  max-width: 100%;
+  width: 100%;
 }
 
 .#{$ns}-select-popover .#{$ns}-menu {
-  max-width: 100%;
+  width: 100%;
 }


### PR DESCRIPTION
- Setting bp-input-ghost width to 100% make it possible to see complete placeholder in MultiSelect component