### PR TITLE
Feature/graph 1170 generate css with blueprint package version

### DIFF
--- a/packages/core/src/common/_customs.scss
+++ b/packages/core/src/common/_customs.scss
@@ -42,7 +42,7 @@ $blue4: #00a1ff;
 $blue5: #47b2f0;
 
 $pt-intent-primary: #0091E4;
-
+$pt-dark-link-color: $pt-intent-primary; // for links
 
 
 // ------------------------- Components -------------------------------

--- a/packages/node-build-scripts/sass-compile.sh
+++ b/packages/node-build-scripts/sass-compile.sh
@@ -16,3 +16,7 @@ $ROOT_NM/.bin/node-sass-chokidar \
   --output $OUTPUT \
   --source-map true \
   $@
+
+PACKAGE_VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g')
+
+sed -i '' "3s/^/Version: ${PACKAGE_VERSION}\ /" $OUTPUT*.css

--- a/packages/node-build-scripts/sass-compile.sh
+++ b/packages/node-build-scripts/sass-compile.sh
@@ -17,6 +17,8 @@ $ROOT_NM/.bin/node-sass-chokidar \
   --source-map true \
   $@
 
+# Read the package.json version property
 PACKAGE_VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g')
 
+# Add the package version to the header of the css output file
 sed -i '' "3s/^/Version: ${PACKAGE_VERSION}\ /" $OUTPUT*.css

--- a/packages/node-build-scripts/sass-compile.sh
+++ b/packages/node-build-scripts/sass-compile.sh
@@ -21,4 +21,4 @@ $ROOT_NM/.bin/node-sass-chokidar \
 PACKAGE_VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g')
 
 # Add the package version to the header of the css output file
-sed -i '' "3s/^/Version: ${PACKAGE_VERSION}\ /" $OUTPUT*.css
+sed -i '' "6s/^/Version: ${PACKAGE_VERSION}\ /" $OUTPUT*.css


### PR DESCRIPTION
- Update `sass-compile.sh` script to include javascript `package.json` version of the corresponding `lerna package` in the output CSSs files.
- Update `$pt-dark-link-color` CSS variable to use our blue color in links.