### PR TITLE
Add -graphext postfix to the versions

### DIFF
--- a/GRAPHEXT_README.md
+++ b/GRAPHEXT_README.md
@@ -6,7 +6,7 @@ This is a fork of [Palantir's blueprint library](https://github.com/palantir/blu
 We should always pull commits of a completed released version of blueprint.
 - If the latest commit of `develop` branch is the last of the desired release, we can retrieve the changes from `upstream develop` into a new branch in `origin`:
 ```
-git checkout graphext && git pull upstream develop
+git checkout updateUpstream && git pull upstream develop
 ```
 - Otherwise, the *pull* must be done from the release's specific commit.
 - Push all incoming commits to the branch created in `origin`.
@@ -20,25 +20,27 @@ The purpose of this repository is to adapt blueprint UI components' styles to Gr
 
   Note that many Blueprint components are build using others Blueprint components. Then, it is important that styles overwriting be done by using specific classnames.
 
+## How to publish the changes
 
-## Generating CSS
-In [graphext](https://github.com/graphext/graphext) repository, `packages/core` and `packages/select` compiled CSSs are used. Note that these CSSs must be always synchronized with their corresponding Javascript versions.
-Steps to generate CSS files:
-- Change to the corresponding directory you want to genetate its CSS. For instance, if you want to generate `packages/core` CSS you can do:
+In the top directory you can complie all the packages
 ```
-cd packages/core
+yarn compile
 ```
-- Run the following command:
+And then create the bundles with
 ```
-yarn run generate-graphext-css
+yarn dist:libs
 ```
-This command compile all `.scss` files into a single `.css`.
-- Update [blueprint-core.global.css](https://github.com/graphext/graphext/blob/master/app/javascript/rsc/blueprint-core.global.css) file in `graphext/app/javascript/rsc/blueprint-core.global.css` with the new CSS located in the lib directory e.g. (`packages/core/lib/css/blueprint.css`).
+After that you can upgrade the version of the changed packages adding +1 after the `graphext` part of the version. Take into account the dependencies between packages, like the icons --> core dependency.
+
+And publish the affected packages like:
+```
+cd packages/core && npm publish
+```
 
 ## How to add new icons
 
 The icons generator script is [`generate-icons-source.js`](packages/node-build-scripts/generate-icons-source.js). This script uses [`packages/icons/resources/icons/icons.json` ](packages/icons/resources/icons/icons.json) as entry, which is the file we have to modify in order to add a new icon.
-- 1. Add a new object at the end of the array:
+- 1. Add a new object at the end of the other Graphext components:
 
 ```
     ...

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/core",
-  "version": "3.9.0",
+  "version": "3.9.0-graphext",
   "description": "Core styles & components",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
@@ -39,7 +39,7 @@
     "verify": "npm-run-all compile -p dist test lint"
   },
   "dependencies": {
-    "@blueprintjs/icons": "^3.3.0",
+    "@blueprintjs/icons": "3.3.0-graphext",
     "@types/dom4": "^2.0.0",
     "classnames": "^2.2",
     "dom4": "^2.0.1",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/icons",
-  "version": "3.3.0",
+  "version": "3.3.0-graphext",
   "description": "Components, fonts, icons, and css files for creating and displaying icons.",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/select",
-  "version": "3.3.0",
+  "version": "3.3.0-graphext",
   "description": "Components related to selecting items from a list",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
@@ -34,7 +34,7 @@
     "verify": "npm-run-all compile -p dist test lint"
   },
   "dependencies": {
-    "@blueprintjs/core": "^3.9.0",
+    "@blueprintjs/core": "3.9.0-graphext",
     "classnames": "^2.2",
     "tslib": "^1.9.0"
   },


### PR DESCRIPTION
This change is required in order to use the icons in graphext. `@blueprint/core` installs `@blueprint/icons` and re exports the types of icons... Me must publish our own copies of the library if we want to use the icons without fighting against everything.

As a consecuence, our `css` can be imported from `node_modules` directly. Thats why I've removed the documentation about exporting the `css`... not needed any more.

This change could open the door for changing the javascript itself... bit I am worry about future conflicts so I prefer to not change the plan and only change `css` files and adding `icons`. 