### PR TITLE
Style checkbox

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/core",
-  "version": "3.9.0-graphext5",
+  "version": "3.9.0-graphext6",
   "description": "Core styles & components",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/core/src/_overrides.scss
+++ b/packages/core/src/_overrides.scss
@@ -120,3 +120,16 @@
 .#{$ns}-transition-container {
   margin-top: 4px;
 }
+
+// CheckBox
+.#{$ns}-control.#{$ns}-checkbox {
+  .#{$ns}-control-indicator {
+    border-radius: 4px;
+    background: $dark-gray5;  // removes gradient
+  }
+  input:checked ~ .#{$ns}-control-indicator{
+    &::before {
+      background-image: svg-icon("16px/g-check.svg", (path: (fill: $white)));
+    }
+  }
+}

--- a/packages/core/src/common/_customs.scss
+++ b/packages/core/src/common/_customs.scss
@@ -95,6 +95,7 @@ $input-box-shadow: none;
 
 // Controls (switch, radio, checkbox)
 $dark-switch-background-color: $dark-gray2;
+$dark-control-background-color-hover: $dark-gray4;
 
 //Tags
 $tag-height: 20px;

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -34,7 +34,7 @@
     "verify": "npm-run-all compile -p dist test lint"
   },
   "dependencies": {
-    "@blueprintjs/core": "3.9.0-graphext5",
+    "@blueprintjs/core": "3.9.0-graphext6",
     "classnames": "^2.2",
     "tslib": "^1.9.0"
   },

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -33,7 +33,7 @@
     "verify": "npm-run-all compile -p dist test lint"
   },
   "dependencies": {
-    "@blueprintjs/core": "3.9.0-graphext5",
+    "@blueprintjs/core": "3.9.0-graphext6",
     "classnames": "^2.2",
     "prop-types": "^15.6.0",
     "tslib": "^1.9.0"


### PR DESCRIPTION
I've styled the checkbox control to unblock the development of the embedings modal. I haven't follow the design for two reasons I want to discuss with @cristinatraba:

1. It has low contrast between states (chacked/unchecked)
2. It is not consistent with the switch affordances (blue background is checked)

I don't pretend that the proposed style is by any means the final one... just an easy way of match the graphext styles.

<img width="192" alt="captura de pantalla 2018-12-28 a las 12 30 16" src="https://user-images.githubusercontent.com/759344/50514167-c5219880-0a9c-11e9-93a4-46d8eba18d13.png">

