### PR TITLE
feat(blueprint): ✨ Upload custom popover2

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -27,6 +27,7 @@ steps:
   - npm publish packages/datetime
   - npm publish packages/table
   - npm publish packages/select
+  - npm publish packages/popover2
   - rm /root/.npmrc
   environment:
     NPMRC:

--- a/GRAPHEXT_README.md
+++ b/GRAPHEXT_README.md
@@ -41,6 +41,7 @@ The following packages of this monorepo have been already updated by Graphext an
     - `select`
     - `icons`
     - `table`
+    - `popover2` 
 
 ## How to publish the changes
 
@@ -63,7 +64,7 @@ After that you can upgrade the version of the changed packages adding +1 after t
 
 And publish the affected packages like:
 ```
-cd packages/core && npm publish && cd ../../ && cd packages/icons && npm publish && cd ../../ && cd packages/datetime && npm publish && cd ../../ && cd packages/table && npm publish && cd ../../ && cd packages/select && npm publish && cd ../../
+cd packages/core && npm publish && cd ../../ && cd packages/icons && npm publish && cd ../../ && cd packages/datetime && npm publish && cd ../../ && cd packages/table && npm publish && cd ../../ && cd packages/select && npm publish && cd ../../ && cd packages/popover2 && npm publish && cd ../../
 ```
 
 ## How to add new icons
@@ -130,4 +131,7 @@ The [first version](https://npm.graphext.com/-/web/detail/@blueprintjs/core/v/3.
 This is how we included the changes from palantir in our repository.
 At this point, we were able to work as we used to do (PR in `graphext` and then if you want to deploy your changes, merge it into `deploy`).
 
-
+### About popover2 situation
+`@blueprint/popover2` package is going to replace `@blueprint/core` popover in `Blueprintjs V5`. 
+The use of this package is recommended to be prepared and also because it is more efficient than the previous one.
+We must take into account that the 'custom' version of this package for graphext exists since `graphext04`, so if we try to use a previous version it will return an error because it does not exist in our private repository.

--- a/graphext-versions.json
+++ b/graphext-versions.json
@@ -3,5 +3,6 @@
   "@blueprintjs/datetime": "3.23.20-graphext04",
   "@blueprintjs/icons": "3.32.0-graphext04",
   "@blueprintjs/select": "3.18.12-graphext04",
-  "@blueprintjs/table": "3.9.14-graphext04"
+  "@blueprintjs/table": "3.9.14-graphext04",
+  "@blueprintjs/popover2": "0.13.0-graphext04"
 }

--- a/packages/demo-app/package.json
+++ b/packages/demo-app/package.json
@@ -19,7 +19,7 @@
     "@blueprintjs/core": "3.53.0-graphext04",
     "@blueprintjs/datetime": "3.23.20-graphext04",
     "@blueprintjs/icons": "3.32.0-graphext04",
-    "@blueprintjs/popover2": "^0.13.0",
+    "@blueprintjs/popover2": "0.13.0-graphext04",
     "@blueprintjs/select": "3.18.12-graphext04",
     "@blueprintjs/table": "3.9.14-graphext04",
     "@blueprintjs/timezone": "^3.9.20",

--- a/packages/docs-app/package.json
+++ b/packages/docs-app/package.json
@@ -21,7 +21,7 @@
     "@blueprintjs/docs-data": "^3.53.0",
     "@blueprintjs/docs-theme": "^3.10.20",
     "@blueprintjs/icons": "3.32.0-graphext04",
-    "@blueprintjs/popover2": "^0.13.0",
+    "@blueprintjs/popover2": "0.13.0-graphext04",
     "@blueprintjs/select": "3.18.12-graphext04",
     "@blueprintjs/table": "3.9.14-graphext04",
     "@blueprintjs/test-commons": "^0.10.14",

--- a/packages/popover2/package.json
+++ b/packages/popover2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueprintjs/popover2",
-  "version": "0.13.0",
+  "version": "0.13.0-graphext04",
   "description": "Popover2 and dependent components",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",

--- a/packages/popover2/src/_common.scss
+++ b/packages/popover2/src/_common.scss
@@ -3,6 +3,7 @@
 
 @import "~@blueprintjs/core/src/common/variables";
 @import "~@blueprintjs/core/src/common/react-transition";
+@import "customs";
 
 $pt-popover2-background-color: $white !default;
 $pt-popover2-box-shadow: $pt-elevation-shadow-3 !default;

--- a/packages/popover2/src/_customs.scss
+++ b/packages/popover2/src/_customs.scss
@@ -1,0 +1,4 @@
+$pt-tooltip2-box-shadow: $custom-shadow;
+
+$dark-tooltip2-background-color: $dark-gray0;
+$dark-tooltip2-text-color: $white1;

--- a/packages/popover2/src/_overrides.scss
+++ b/packages/popover2/src/_overrides.scss
@@ -1,0 +1,4 @@
+.#{$ns}-tooltip, .#{$ns}-tooltip .#{$ns}-popover-content {
+  border-radius: $pt-grid-size;
+  font-size: 12px;
+}

--- a/packages/popover2/src/_tooltip2.scss
+++ b/packages/popover2/src/_tooltip2.scss
@@ -73,3 +73,5 @@ $tooltip2-padding-horizontal: 1.2 * $pt-grid-size !default;
   border-bottom: dotted 1px;
   cursor: help;
 }
+
+@import "overrides";


### PR DESCRIPTION
### Popover2:
With the update of the new versión of `blueprintjs` we were able to use **popover2** but adapting and publishing our custom version of the package was required. That's what this Pull request is all about 🥸

### Things done:

- Updated package versions in related files.
- Adapted graphext styles of `core/tooltip` and `core/popover`.
- Updated readme file.
- Checked that syncVersions.js works well with popover2

### To have into account:
In order to avoid upgrading a version in packages that didn't have any real change (like core, table, etc) **popover2** was uploaded from local to our npm repository with version `graphext04`.

Also, drone will fail when merged to deploy (because it tries to publish all packages, and part of them are published already) and is required to sign the new drone file ( @militarpancho )