### PR TITLE
fix(blueprint): 🐛 Incorrect <Input/> intent

### DIFF
--- a/packages/core/src/components/forms/_customs.scss
+++ b/packages/core/src/components/forms/_customs.scss
@@ -5,9 +5,9 @@ $input-font-weight: 300;
 $dark-input-background-color: rgba($dark-gray0, 0.3);
 $dark-input-shadow-color-focus: transparent;
 
-$input-box-shadow: none;
-$input-box-shadow-focus: none;
-$pt-dark-input-box-shadow: none;
+$input-box-shadow: 0 0 0 0 transparent;
+$input-box-shadow-focus: 0 0 0 0 transparent;
+$pt-dark-input-box-shadow: 0 0 0 0 transparent;
 
 
 // Controls

--- a/packages/core/src/components/forms/_overrides.scss
+++ b/packages/core/src/components/forms/_overrides.scss
@@ -89,7 +89,7 @@
   box-sizing: border-box;
   padding-left: $input-padding-horizontal;
   padding-right: $input-padding-horizontal;
-  box-shadow: none !important;
+  box-shadow: none;
 
   &.#{$ns}-large {
     padding: 0 $input-padding-horizontal * 1.5;
@@ -100,7 +100,7 @@
 // Numeric Input Control Group
 .#{$ns}-numeric-input {
   .#{$ns}-button-group.#{$ns}-vertical > .#{$ns}-button {
-    box-shadow: none !important;
+    box-shadow: none;
     background-color: $dark-gray4;
 
     & > .#{$ns}-icon{


### PR DESCRIPTION
### BUG:
`<Input />` component doesn't get the right intent 'border' color.

### VIDEO:

https://user-images.githubusercontent.com/97446955/169543057-8ae58233-f23b-4199-9982-771504ea83a5.mov

### SOLUTION:
There was a `!important` overriding the intents behaviour.

### VIDEO:

https://user-images.githubusercontent.com/97446955/169543366-13eeb5a1-3386-4d79-b193-4a335218f4cf.mov


