### PR TITLE
fix(tag): 🐛 Fix opacity percentage

### DIFF
--- a/GRAPHEXT_README.md
+++ b/GRAPHEXT_README.md
@@ -140,3 +140,6 @@ We must take into account that the 'custom' version of this package for graphext
 
 There are some special commands on `docker-compose.yml` created to work easier with Graphext, Storybook and Blueprint.
 There is more information about it on **WORKING WITH 🔵 BLUEPRINT** section of [Storybook readme.](https://pre.graphext.com/storybook/?path=/story/design-system-how-to-use--page)
+
+## Warning:
+**DO NOT USE the `%` on CSS Opacity because it breaks on Graphext build**, use instead `opacity: 0.5;` for example.

--- a/graphext-versions.json
+++ b/graphext-versions.json
@@ -1,8 +1,8 @@
 {
-  "@blueprintjs/core": "3.53.0-graphext38",
-  "@blueprintjs/datetime": "3.23.20-graphext38",
-  "@blueprintjs/icons": "3.32.0-graphext38",
-  "@blueprintjs/select": "3.18.12-graphext38",
-  "@blueprintjs/table": "3.9.14-graphext38",
-  "@blueprintjs/popover2": "0.13.0-graphext38"
+  "@blueprintjs/core": "3.53.0-graphext39",
+  "@blueprintjs/datetime": "3.23.20-graphext39",
+  "@blueprintjs/icons": "3.32.0-graphext39",
+  "@blueprintjs/select": "3.18.12-graphext39",
+  "@blueprintjs/table": "3.9.14-graphext39",
+  "@blueprintjs/popover2": "0.13.0-graphext39"
 }

--- a/packages/core/src/components/tag/_overrides.scss
+++ b/packages/core/src/components/tag/_overrides.scss
@@ -242,7 +242,7 @@
 
     &.#{$ns}-g-disabled {
       background-color: transparent;
-      opacity: 60%;
+      opacity: 0.6;
 
       &.#{$ns}-interactive {
         cursor: pointer;
@@ -257,7 +257,7 @@
       &.#{$ns}-active,
       &:active {
         background-color: $g-light-base5;
-        opacity: 100%;
+        opacity: 1;
       }
     }
 
@@ -273,7 +273,7 @@
         &.#{$ns}-active,
         &:active {
           background-color: $g-dark-base5;
-          opacity: 100%;
+          opacity: 1;
         }
       }
 


### PR DESCRIPTION
This bug (see also [this PR](https://github.com/graphext/graphext/pull/2079)) makes that all `opacity` made with `%` breaks in the build time of Graphext.

@LunaFidalgo found that the bug probably comes from [here](https://github.com/parcel-bundler/parcel/issues/5207)