### PR TITLE
feat: improve light theme colors

### DIFF
--- a/packages/core/src/components/dialog/_customs.scss
+++ b/packages/core/src/components/dialog/_customs.scss
@@ -2,4 +2,6 @@ $dialog-border-radius: 8px;
 $dialog-margin: 24px;
 $dialog-padding: 24px;
 
+/* Dialog background */
 $pt-dark-app-background-color: $g-dark-base2;
+$light-gray4: $g-light-base2;

--- a/packages/core/src/components/forms/_customs.scss
+++ b/packages/core/src/components/forms/_customs.scss
@@ -9,6 +9,8 @@ $input-box-shadow: 0 0 0 0 transparent;
 $input-box-shadow-focus: 0 0 0 0 transparent;
 $pt-dark-input-box-shadow: 0 0 0 0 transparent;
 
+$input-placeholder-color: $g-dark-grey3;
+
 
 // Controls
 $dark-switch-background-color: $dark-gray2;

--- a/packages/core/src/components/forms/_customs.scss
+++ b/packages/core/src/components/forms/_customs.scss
@@ -9,8 +9,6 @@ $input-box-shadow: 0 0 0 0 transparent;
 $input-box-shadow-focus: 0 0 0 0 transparent;
 $pt-dark-input-box-shadow: 0 0 0 0 transparent;
 
-$input-placeholder-color: $g-dark-grey3;
-
 
 // Controls
 $dark-switch-background-color: $dark-gray2;

--- a/packages/core/src/components/forms/_overrides.scss
+++ b/packages/core/src/components/forms/_overrides.scss
@@ -132,9 +132,9 @@
 // (every input is a round input for us)
 .#{$ns}-input {
     &::placeholder {
-      color: $g-light-grey2 !important;
+      color: $g-light-grey3 !important;
       .#{$ns}-dark & {
-        color: $g-dark-grey2 !important;
+        color: $g-dark-grey3 !important;
       }
     }
 

--- a/packages/core/src/components/forms/_overrides.scss
+++ b/packages/core/src/components/forms/_overrides.scss
@@ -53,16 +53,37 @@
   }
 }
 
+/**
+  * BP uses box-shadow to add border without changing the size of the element.
+ *  Here we use it to add a subtle border in elements like: checkbox & radio button.
+ */
+@mixin box-shadow-as-border($color) {
+  box-shadow: inset 0 0 0 1px $color !important;
+}
+
+
 
 // CheckBox
+/**
+* We want a custom checked state: we change the background-image added with ::before selector.
+* Also, we want custom colors.
+*/
 .#{$ns}-control {
   &.#{$ns}-checkbox {
     .#{$ns}-control-indicator {
       border-radius: 4px;
-      box-shadow: none;
+      @include box-shadow-as-border($g-light-grey4);
 
       .#{$ns}-dark & {
-        box-shadow: none;
+        @include box-shadow-as-border($g-dark-grey4);
+      }
+    }
+
+    input:checked ~ .#{$ns}-control-indicator,
+    input:indeterminate ~ .#{$ns}-control-indicator {
+      @include box-shadow-as-border($g-primary-100);
+      .#{$ns}-dark & {
+        @include box-shadow-as-border($g-primary-700);
       }
     }
     input:checked ~ .#{$ns}-control-indicator{
@@ -75,20 +96,33 @@
 
 
 // Radio
+/**
+* We use the opposite colors that BP proposes for checked radio:
+*   - BP: center white and border blue
+*   - Graphext: center blue and border white
+*/
+
 .#{$ns}-control {
   &.#{$ns}-radio {
+    .#{$ns}-control-indicator {
+      @include box-shadow-as-border($g-light-grey4);
+      .#{$ns}-dark & {
+        @include box-shadow-as-border($g-dark-grey4);
+      }
+    }
+
     input:checked ~ .#{$ns}-control-indicator::before {
       background-image: radial-gradient($pt-intent-primary, $pt-intent-primary 33%, transparent 37%);
     }
+
     input:checked ~ .#{$ns}-control-indicator {
       background-color: $g-light-base4;
-    }
-  }
-}
-.#{$ns}-dark .#{$ns}-control {
-  &.#{$ns}-radio {
-    input:checked ~ .#{$ns}-control-indicator {
-      background-color: $g-dark-base4;
+      @include box-shadow-as-border($g-primary-100);
+
+      .#{$ns}-dark & {
+        background-color: $g-dark-base4;
+        @include box-shadow-as-border($g-primary-700);
+      }
     }
   }
 }
@@ -97,12 +131,24 @@
 // Inputs
 // (every input is a round input for us)
 .#{$ns}-input {
+    &::placeholder {
+      color: $g-light-grey2 !important;
+      .#{$ns}-dark & {
+        color: $g-dark-grey2 !important;
+      }
+    }
+
+  font-weight: normal;
   border-radius: $pt-input-height / 2;
   box-sizing: border-box;
   padding-left: $input-padding-horizontal;
   padding-right: $input-padding-horizontal;
   box-shadow: none;
 
+  color: black;
+  .#{$ns}-dark & {
+    color: white;
+  }
   &.#{$ns}-large {
     padding: 0 $input-padding-horizontal * 1.5;
   }

--- a/packages/core/src/components/forms/_overrides.scss
+++ b/packages/core/src/components/forms/_overrides.scss
@@ -78,16 +78,18 @@
 .#{$ns}-control {
   &.#{$ns}-radio {
     input:checked ~ .#{$ns}-control-indicator::before {
-      background-image: radial-gradient($pt-intent-primary, $pt-intent-primary 28%, transparent 32%);
+      background-image: radial-gradient($pt-intent-primary, $pt-intent-primary 33%, transparent 37%);
     }
-    input:checked ~ .#{$ns}-control-indicator{
-      background-color: $dark-gray5;
+    input:checked ~ .#{$ns}-control-indicator {
+      background-color: $g-light-base4;
     }
   }
 }
 .#{$ns}-dark .#{$ns}-control {
-  &.#{$ns}-radio:hover input:checked~.#{$ns}-control-indicator{
-    background-color: $dark-gray5;
+  &.#{$ns}-radio {
+    input:checked ~ .#{$ns}-control-indicator {
+      background-color: $g-dark-base4;
+    }
   }
 }
 
@@ -111,9 +113,13 @@
 .#{$ns}-numeric-input {
   .#{$ns}-button-group.#{$ns}-vertical > .#{$ns}-button {
     box-shadow: none;
-    background-color: $dark-gray4;
+    background-color: $g-light-base4;
 
-    & > .#{$ns}-icon{
+    .#{$ns}-dark & {
+      background-color: $g-dark-base4;
+    }
+
+    & > .#{$ns}-icon {
       transform: scale(0.8);
       color: $pt-intent-primary;
     }


### PR DESCRIPTION
## Improve light theme
This PR fixes: 
- Dialog background color was not correct in light mode.
- Input placeholder wasn't noticeable in light theme. 
- Input radio button.
- Numeric input (the arrows always appeared in dark colors).