### PR TITLE
Feature/graph 6273 update bp components

### DIFF
--- a/packages/core/src/common/_customs.scss
+++ b/packages/core/src/common/_customs.scss
@@ -198,6 +198,9 @@ $g-primary-700: #0066A0;
 $g-primary-800: #005789;
 $g-primary-900: #112446;
 
+$g-light-active: $g-primary-400;
+$g-dark-active: $g-primary-600;
+
 $g-wizard-23-25: #FEFEFF;
 $g-wizard-23-50: #F7F8FD;
 $g-wizard-23-100: #EAEEFA;

--- a/packages/core/src/components/button/_overrides.scss
+++ b/packages/core/src/components/button/_overrides.scss
@@ -128,7 +128,7 @@ $pt-gp-dark-icon-color: $g-white;
       @include custom-button-kind(secondary, $g-primary-300, $g-light-base5, $g-primary-100);
       @include custom-button-kind(stroked, $g-black, $g-light-base5, $g-primary-100);
       @include custom-button-kind(ghost, $g-primary-300, $g-light-base5, $g-primary-100);
-      @include custom-button-kind(group, $g-white, $g-primary-300);
+      @include custom-button-kind(group, $g-white, $g-primary-400);
     }
 
     &:disabled,

--- a/packages/core/src/components/forms/_customs.scss
+++ b/packages/core/src/components/forms/_customs.scss
@@ -3,9 +3,11 @@ $input-padding-horizontal: $pt-grid-size * 2;
 $input-font-weight: 300;
 
 $dark-input-background-color: $g-dark-base4;
+$dark-input-background-color-disabled: $g-dark-base4;
 $dark-input-shadow-color-focus: transparent;
 
 $input-background-color: $g-light-base4;
+$input-background-color-disabled: $g-light-base4;
 $input-shadow-color-focus: transparent;
 
 $input-box-shadow: 0 0 0 0 transparent;

--- a/packages/core/src/components/forms/_overrides.scss
+++ b/packages/core/src/components/forms/_overrides.scss
@@ -81,15 +81,30 @@
 
     input:checked ~ .#{$ns}-control-indicator,
     input:indeterminate ~ .#{$ns}-control-indicator {
+      background-color: $g-light-active;
       @include box-shadow-as-border($g-primary-100);
+
       .#{$ns}-dark & {
+       background-color: $g-dark-active;
         @include box-shadow-as-border($g-primary-700);
       }
     }
-    input:checked ~ .#{$ns}-control-indicator{
+
+    input:checked ~ .#{$ns}-control-indicator {
       &::before {
         background-image: svg-icon("16px/g-check.svg", (path: (fill: $white)));
       }
+    }
+  }
+}
+
+.#{$ns}-control:hover {
+  input:checked ~ .#{$ns}-control-indicator,
+  input:indeterminate ~ .#{$ns}-control-indicator {
+    background-color: $g-primary-500 !important;
+
+    .#{$ns}-dark & {
+      background-color: $g-primary-700 !important;
     }
   }
 }
@@ -151,6 +166,15 @@
       color: $g-light-grey3 !important;
       .#{$ns}-dark & {
         color: $g-dark-grey3 !important;
+      }
+    }
+
+    &:disabled {
+      &::placeholder {
+        color: $g-light-grey4 !important;
+        .#{$ns}-dark & {
+          color: $g-dark-grey4 !important;
+        }
       }
     }
 

--- a/packages/core/src/components/menu/_customs.scss
+++ b/packages/core/src/components/menu/_customs.scss
@@ -1,6 +1,10 @@
 $menu-item-border-radius: $pt-border-radius;
 
-$dark-menu-item-color-hover: $dark-gray5;
-$dark-menu-item-color-active: $dark-gray5 !important; // Important is needed here because the classname "bp3-intent-primary" applied to active menu items.
+$dark-menu-item-color-hover: $g-dark-base5;
+$dark-menu-item-color-active: $g-dark-base5 !important; // Important is needed here because the classname "bp3-intent-primary" applied to active menu items.
+
+$menu-item-color-hover: $g-light-base5;
+$menu-item-color-active: $g-light-base5 !important;
 
 $dark-menu-background-color: $g-dark-base3; // Same background as Popover
+$menu-background-color: $g-light-base3;

--- a/packages/core/src/components/menu/_menu.scss
+++ b/packages/core/src/components/menu/_menu.scss
@@ -195,3 +195,5 @@ Styleguide menu-header
 .#{$ns}-label .#{$ns}-menu {
   margin-top: $pt-grid-size / 2;
 }
+
+@import "overrides";

--- a/packages/core/src/components/menu/_overrides.scss
+++ b/packages/core/src/components/menu/_overrides.scss
@@ -1,0 +1,28 @@
+.#{$ns}-menu-item.#{$ns}-active {
+  color: $g-black !important;
+  .#{$ns}-menu-item-label {
+    color: $g-black !important;
+  }
+}
+
+.#{$ns}-dark {
+  .#{$ns}-menu-item.#{$ns}-active {
+    color: $g-white !important;
+    .#{$ns}-menu-item-label {
+      color: $g-white !important;
+    }
+  }
+}
+
+/**
+* Necessary to fix BP omnibar documentation
+* because they use text-muted and it was difficult to read because of the color contrast
+**/
+.#{$ns}-omnibar.docs-navigator-menu {
+  .#{$ns}-menu-item.#{$ns}-active {
+    .#{$ns}-text-muted {
+      color: $g-light-grey1 !important;
+    }
+  }
+}
+

--- a/packages/core/src/components/slider/_overrides.scss
+++ b/packages/core/src/components/slider/_overrides.scss
@@ -1,13 +1,62 @@
-.#{$ns}-dark .#{$ns}-slider-handle, .#{$ns}-dark .#{$ns}-slider-handle:hover{
-  background-color: $pt-intent-primary;
+/** Handler color */
+.#{$ns}-dark .#{$ns}-slider-handle,
+.#{$ns}-dark .#{$ns}-slider-handle:hover {
+  background-color: $g-dark-active;
+  background-image: none;
 }
-.#{$ns}-dark .#{$ns}-slider-handle:active, .#{$ns}-dark .#{$ns}-slider-handle.#{$ns}-active{
-  background-color: $pt-intent-primary;
+
+.#{$ns}-dark .#{$ns}-slider-handle:active,
+.#{$ns}-dark .#{$ns}-slider-handle.#{$ns}-active {
+  background-color: $g-dark-active;
 }
-.#{$ns}-slider-label{
+
+.#{$ns}-slider-handle,
+.#{$ns}-slider-handle:hover {
+  background-color: $g-light-active;
+  background-image: none;
+}
+
+.#{$ns}-slider-handle:active,
+.#{$ns}-slider-handle.#{$ns}-active {
+  background-color: $g-light-active;
+}
+
+/* progress bar color */
+.#{$ns}-slider-progress.#{$ns}-intent-primary {
+  background-color: $g-light-active;
+}
+
+.#{$ns}-dark .#{$ns}-slider-progress.#{$ns}-intent-primary {
+  background-color: $g-dark-active;
+}
+
+/* slider label */
+.#{$ns}-slider-label {
   padding: 4px 8px;
   font-size: 11px;
 }
-.#{$ns}-slider.#{$ns}-axis-hidden .#{$ns}-slider-axis{
+
+.#{$ns}-slider.#{$ns}-axis-hidden .#{$ns}-slider-axis {
   display: none;
+}
+
+.#{$ns}-slider-label {
+  color: $g-light-grey2 !important;
+}
+
+.#{$ns}-slider-handle .#{$ns}-slider-label {
+  background-color: $g-light-base1 !important;
+  color: $g-black !important;
+  border-radius: 4px;
+}
+
+.#{$ns}-dark {
+  .#{$ns}-slider-label {
+    color: $g-dark-grey4;
+
+  }
+  .#{$ns}-slider-handle .#{$ns}-slider-label {
+    background-color: $g-dark-base0 !important;
+    color: $g-white !important;
+  }
 }

--- a/packages/core/src/components/tag-input/_overrides.scss
+++ b/packages/core/src/components/tag-input/_overrides.scss
@@ -5,6 +5,13 @@
     width: 100%;
     font-size: 14px;
     line-height: 16px;
+
+    &::placeholder {
+      color: $g-light-grey3 !important;
+      .#{$ns}-dark & {
+        color: $g-dark-grey3 !important;
+      }
+    }
   }
 }
 
@@ -14,13 +21,13 @@
   border-radius: 24px;
   padding-left: 8px;
   box-shadow: $custom-shadow;
-  color: black;
+  color: $g-black;
   font-size: 16px;
   font-weight: normal;
 
   .#{$ns}-dark & {
     background-color: $g-dark-base3;
-    color: white;
+    color: $g-white;
   }
 
 }


### PR DESCRIPTION
## Light theme improvements
This PR includes: 
1. [Typeahead (menu) default color](https://graphext.atlassian.net/browse/GRAPH-9174)
2. [Slider colors](https://graphext.atlassian.net/browse/GRAPH-9175)
3. [Button Group color](https://graphext.atlassian.net/browse/GRAPH-9176)
4. [Input tag placeholder color](https://graphext.atlassian.net/browse/GRAPH-9173)
5. Input colors (background) when disabled

This beta version was generated to test the changes: "...graphext67-beta2"
