### PR TITLE
Feature/improve table colors

### DIFF
--- a/packages/core/src/components/popover/_customs.scss
+++ b/packages/core/src/components/popover/_customs.scss
@@ -1,2 +1,5 @@
 $dark-popover-background-color: $g-dark-base3;
 $popover-background-color: $g-light-base3;
+
+$pt-dark-popover-box-shadow: $g-shadow-dark-1;
+$pt-popover-box-shadow: $g-shadow-light-1;

--- a/packages/table/src/_overrides.scss
+++ b/packages/table/src/_overrides.scss
@@ -11,6 +11,10 @@
 .#{$ns}-table-striped {
 
     .#{$ns}-table-row-headers {
+      color: $g-black;
+      .#{$ns}-dark & {
+        color: $g-white;
+      }
       .#{$ns}-table-header[class$="0"],
       .#{$ns}-table-header[class$="2"],
       .#{$ns}-table-header[class$="4"],

--- a/packages/table/src/cell/_overrides.scss
+++ b/packages/table/src/cell/_overrides.scss
@@ -37,7 +37,7 @@
 
 @mixin pt-table-borders-mixin($border-width, $frozen-border-width, $border-color) {
   $border-right-default: $border-width 0 0 $border-color;
-  $border-bottom-default: 0 $border-width 0 transparent;
+  $border-bottom-default: 0 $border-width 0 $border-color;
   $inset-border-right-default: inset (-$border-width) 0 0 $border-color;
   $inset-border-bottom-default: inset 0 (-$border-width) 0 transparent;
   $inset-border-right-frozen: inset (-$frozen-border-width) 0 0 $border-color;
@@ -99,6 +99,8 @@
   }
 
   .#{$ns}-table-quadrant-top-left {
+    border-bottom: $border-width solid $border-color;
+    border-right: $border-width solid $border-color;
     .#{$ns}-table-cell {
       &.#{$ns}-table-last-in-row {
         box-shadow: $inset-border-bottom-default, $inset-border-right-frozen;

--- a/packages/table/src/common/_customs.scss
+++ b/packages/table/src/common/_customs.scss
@@ -3,7 +3,7 @@
 $dark-table-background-color: $g-dark-base3;
 $dark-cell-background-color: $g-dark-base3;
 
-$dark-cell-border-color: $dark-gray4;
+$dark-cell-border-color: $g-dark-base5;
 $dark-cell-text-color: $g-white;
 
 $dark-header-background-color: $g-dark-base3;

--- a/packages/table/src/headers/_overrides.scss
+++ b/packages/table/src/headers/_overrides.scss
@@ -22,9 +22,11 @@
 
   &.#{$ns}-table-header-selected::before {
     background-image: none;
+    /* #191919 (black) with 8% opacity */
     background-color: rgba(25, 25, 25, 0.08);
 
     .#{$ns}-dark & {
+      /* #FFF (white) with 8% opacity */
       background-color: rgba(255, 255, 255, 0.08);
     }
   }
@@ -34,9 +36,11 @@
 .#{$ns}-table-header.#{$ns}-table-header-selected {
   .#{$ns}-table-selection-enabled &:hover {
     &::before {
+      /* #191919 (black) with 8% opacity */
       background-color: rgba(25, 25, 25, 0.08);
 
       .#{$ns}-dark & {
+        /* #FFF (white) with 8% opacity */
         background-color: rgba(255, 255, 255, 0.08);
       }
     }


### PR DESCRIPTION
## Improve colors & shadow
1. Popover shadow => popover2 was fixed, but I noticed that some core components are still using popover internally
2. Table colors to achieve this (row numbers & borders in top-left menu)

![image](https://user-images.githubusercontent.com/36133677/236499910-f174bc5a-ddb3-41ee-9c35-cac115681234.png)
