### PR TITLE
feat(Colors): update and clean colors

### DIFF
--- a/packages/core/src/common/_customs.scss
+++ b/packages/core/src/common/_customs.scss
@@ -26,41 +26,6 @@ $pt-button-height-large: 40px;
 
 
 // ------------------------- Colors -----------------------------------
-
-$black: #000000;
-
-$dark-gray0: #161616;
-$dark-gray1: #1F2024;
-$dark-gray2: #272A33;
-$dark-gray3: #2A2E38;
-$dark-gray4: #313641;
-$dark-gray5: #363B47;
-
-$blue1: #00507f;
-$blue2: #0071b2;
-$blue3: #0091e5;
-$blue4: #00a1ff;
-$blue5: #47b2f0;
-
-$green1: #0a6640;
-$green2: #0d8050;
-$green3: #0f9960;
-$green4: #15b371;
-$green5: #3dcc91;
-
-$orange1: #a66321;
-$orange2: #bf7326;
-$orange3: #d9822b;
-$orange4: #f29d49;
-$orange5: #ffb366;
-
-$red1: #a82a2a;
-$red2: #c23030;
-$red3: #db3737;
-$red4: #f55656;
-$red5: #ff7373;
-
-
 // Custom colors with shades:
 
 // $g-example-25: ;
@@ -225,11 +190,6 @@ $g-highlight-700: #595C65;
 $g-highlight-800: #3C3E43;
 $g-highlight-900: #1E1F22;
 
-$white1: #ffffff;
-$white2: rgba(255, 255, 255, 0.8);
-$white3: rgba(255, 255, 255, 0.5);
-$white4: rgba(255, 255, 255, 0.3);
-
 $g-white: #FFF;
 $g-black: #191919;
 
@@ -249,27 +209,9 @@ $pt-link-color: $g-light-active; // for links
 $g-light-highlight-hover: $g-highlight-600;
 $g-dark-highlight-hover: $g-highlight-500;
 
-
-// ------------------------- Color aliases -------------------------------
-
-$pt-dark-icon-color: $white3;
-$pt-dark-icon-color-hover: $white3;
-
-$pt-dark-divider-black: $white3;
-
-
-// ------------------------- Components -------------------------------
-
-// Custom shadow for buttons, selects, tag-inputs, tooltips & datetime
-$custom-shadow: 0 0 12px rgba($black, 0.25);
-
-// Custom shadow for popover (New Design System)
-$pt-dark-border-shadow-opacity: 0.1;
-
 $g-shadow-light-1: 0px 4px 4px 0px hsla(0, 0%, 30%, 0.1), 0px -1px 4px 0px hsla(0, 0%, 30%, 0.1);
 $g-shadow-light-2: 0px 8px 8px 0px hsla(0, 0%, 30%, 0.1), 0px -1px 8px 0px hsla(0, 0%, 30%, 0.1);
 $g-shadow-light-3: 0px 16px 16px 0px hsla(0, 0%, 30%, 0.1), 0px -1px 16px 0px hsla(0, 0%, 30%, 0.1);
-
 
 $g-shadow-dark-1: 0px 4px 4px 0px hsla(0, 0%, 8%, 0.3), 0px -1px 4px 0px hsla(0, 0%, 8%, 0.3);
 $g-shadow-dark-2: 0px 8px 8px 0px hsla(0, 0%, 8%, 0.3), 0px -1px 8px 0px hsla(0, 0%, 8%, 0.3);
@@ -278,25 +220,13 @@ $g-shadow-dark-3: 0px 16px 16px 0px hsla(0, 0%, 8%, 0.3), 0px -1px 16px 0px hsla
 
 // ------------------------- New Design System Colors -------------------------------
 
-// Functions to get tint effect
-@function tint($color, $percentage) {
-  @return mix(white, $color, $percentage);
-}
+$g-dark-grey1: #D7D8DB;
+$g-dark-grey2: #A2A4A9;
+$g-dark-grey3: #63656B;
 
-// Functions to get shade effect
-@function shade($color, $percentage) {
-  @return mix(black, $color, $percentage);
-}
-
-$g-dark-grey1: #D8D8DA;
-$g-dark-grey2: #D7D8DB;
-$g-dark-grey3: #A2A4A9;
-$g-dark-grey4: #63656B;
-
-$g-light-grey1: #61646B;
-$g-light-grey2: #404040;
-$g-light-grey3: #808080;
-$g-light-grey4: #CCCCCC;
+$g-light-grey1: #404040;
+$g-light-grey2: #808080;
+$g-light-grey3: #cccccc;
 
 $g-dark-base0: #161616;
 $g-dark-base1: #1F2024;
@@ -314,14 +244,6 @@ $g-light-base4: #FCFCFD;
 $g-light-base5: #DEDEDE;
 $g-light-base6: #F2FAFE;
 
-
-// all shadow lists must be the same length to avoid flicker in transitions.
-$pt-elevation-shadow-0: 0 0 0 1px transparent,
-  0 0 0 rgba($black, 0),
-  0 0 0 rgba($black, 0) !default;
-$pt-dark-elevation-shadow-0: 0 0 0 1px transparent,
-  0 0 0 rgba($black, 0),
-  0 0 0 rgba($black, 0) !default;
 
 $pt-intent-text-colors: (
   "primary": $g-light-active,
@@ -352,5 +274,28 @@ $pt-g-dark-intent-colors: (
   "danger" : $g-error-600,
 );
 
+/* common variables used by BP: don't override them in _customs.scss files */
+$pt-text-color-muted: $g-light-grey1;
+$pt-text-color-disabled: $g-light-grey3;
+
+$pt-dark-text-color-muted: $g-dark-grey1;
+$pt-dark-text-color-disabled: $g-dark-grey3;
+
 $pt-divider-black: $g-light-base5;
 $pt-dark-divider-black: $g-dark-base5;
+
+$pt-elevation-shadow-3: $g-shadow-light-1;
+$pt-dark-elevation-shadow-3: $g-shadow-dark-1;
+
+$pt-elevation-shadow-4: $g-shadow-light-3;
+
+$pt-icon-color: $g-black;
+$pt-icon-color-hover: $g-black;
+
+$pt-dark-icon-color: $g-white;
+$pt-dark-icon-color-hover: $g-white;
+
+$pt-transition-duration: 250ms;
+
+$pt-dark-text-color: $g-white;
+$pt-text-color: $g-black;

--- a/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/packages/core/src/components/breadcrumbs/_breadcrumbs.scss
@@ -3,7 +3,7 @@
 
 @import "~@blueprintjs/icons/src/icons";
 @import "../../common/variables";
-@import "customs";
+
 /*
 Breadcrumbs
 

--- a/packages/core/src/components/breadcrumbs/_customs.scss
+++ b/packages/core/src/components/breadcrumbs/_customs.scss
@@ -1,6 +1,0 @@
-$pt-text-color-muted: $g-light-grey2;
-$pt-text-color-disabled: $g-light-grey4;
-
-$pt-dark-text-color-muted: $g-dark-grey2;
-$pt-dark-text-color-disabled: $g-dark-grey4;
-

--- a/packages/core/src/components/breadcrumbs/_overrides.scss
+++ b/packages/core/src/components/breadcrumbs/_overrides.scss
@@ -9,3 +9,18 @@
     }
   }
 }
+
+.#{$ns}-breadcrumb {
+  color: $g-black;
+
+  .#{$ns}-dark & {
+    color: $g-white;
+  }
+}
+
+.#{$ns}-breadcrumb.#{$ns}-disabled {
+  color: $g-light-grey1;
+  .#{$ns}-dark & {
+    color: $g-dark-grey1;
+  }
+}

--- a/packages/core/src/components/button/_customs.scss
+++ b/packages/core/src/components/button/_customs.scss
@@ -4,6 +4,7 @@ $pt-button-border-radius: $pt-button-height-large / 2;
 
 $button-border-width: 0;
 
+/*
 $button-box-shadow: $custom-shadow;
 $button-box-shadow-active: $custom-shadow;
 $button-box-shadow-overlay: $custom-shadow;
@@ -12,6 +13,7 @@ $button-intent-box-shadow: $custom-shadow;
 $button-intent-box-shadow-active: $custom-shadow;
 $dark-button-box-shadow: $custom-shadow;
 $dark-button-box-shadow-active: $custom-shadow;
+ */
 
 $dark-minimal-button-background-color-hover: rgba($dark-gray5, 0.15);
 $dark-minimal-button-background-color-active: rgba($dark-gray5, 0.3);

--- a/packages/core/src/components/button/_overrides.scss
+++ b/packages/core/src/components/button/_overrides.scss
@@ -90,11 +90,11 @@ $pt-gp-dark-icon-color: $g-white;
   // Custom loading spinner inside Button:
   .#{$ns}-spinner {
     .#{$ns}-spinner-track {
-      stroke: $g-dark-grey1;
+      stroke: $g-dark-grey2;
     }
 
     .#{$ns}-spinner-head {
-      stroke: $g-dark-grey4;
+      stroke: $g-dark-grey3;
     }
 
     svg {
@@ -182,7 +182,7 @@ $pt-gp-dark-icon-color: $g-white;
       }
 
       .#{$ns}-spinner-head {
-        stroke: $g-dark-grey4;
+        stroke: $g-dark-grey3;
       }
 
       svg {
@@ -220,7 +220,7 @@ $pt-gp-dark-icon-color: $g-white;
       &.#{$ns}-disabled {
         @include custom-button-kind(primary, $g-primary-400, $g-primary-700);
         @include custom-button-kind(secondary, $g-primary-700, $g-dark-base3);
-        @include custom-button-kind(stroked, $g-dark-grey4, transparent, $g-primary-700);
+        @include custom-button-kind(stroked, $g-dark-grey3, transparent, $g-primary-700);
         @include custom-button-kind(ghost, $g-primary-700, transparent, transparent);
         @include custom-button-kind(group, $g-dark-grey3, $g-dark-base3);
       }
@@ -251,7 +251,7 @@ $pt-gp-dark-icon-color: $g-white;
       &.#{$ns}-disabled {
         @include custom-button-kind(primary, $g-error-400, $g-error-700);
         @include custom-button-kind(secondary, $g-error-700, $g-dark-base3);
-        @include custom-button-kind(stroked, $g-dark-grey4, transparent, $g-error-700);
+        @include custom-button-kind(stroked, $g-dark-grey3, transparent, $g-error-700);
         @include custom-button-kind(ghost, $g-error-700, transparent, transparent);
       }
     }

--- a/packages/core/src/components/card/_customs.scss
+++ b/packages/core/src/components/card/_customs.scss
@@ -3,6 +3,3 @@ $dark-card-background-color: $g-dark-base3;
 
 $card-hover-border-color: $g-light-base5;
 $dark-card-hover-border-color: $g-dark-base5;
-
-$pt-elevation-shadow-3: $g-shadow-light-1;
-$pt-dark-elevation-shadow-3: $g-shadow-dark-1;

--- a/packages/core/src/components/drawer/_customs.scss
+++ b/packages/core/src/components/drawer/_customs.scss
@@ -4,5 +4,4 @@ $drawer-padding: 0 20px;
 $dark-drawer-background-color: $g-dark-base2;
 $drawer-background-color: $g-light-base2;
 
-$pt-elevation-shadow-4: $g-shadow-light-3;
 $pt-dialog-box-shadow: $g-shadow-dark-3;

--- a/packages/core/src/components/editable-text/_overrides.scss
+++ b/packages/core/src/components/editable-text/_overrides.scss
@@ -31,7 +31,6 @@
   &::placeholder {
     color: $input-placeholder-color !important;
     .#{$ns}-dark & {
-      /* $dark-input-placeholder-color variable in '_editable-text.scss' is overwritten in '_customs.scss' but is not working */
       color: $dark-input-placeholder-color !important;
     }
   }

--- a/packages/core/src/components/forms/_customs.scss
+++ b/packages/core/src/components/forms/_customs.scss
@@ -5,20 +5,19 @@ $input-font-weight: 300;
 $dark-input-background-color: $g-dark-base4;
 $dark-input-background-color-disabled: $g-dark-base4;
 $dark-input-shadow-color-focus: transparent;
-$input-color-disabled: $g-light-grey3 !default;
-
+$input-color-disabled: $g-light-grey2 !default;
 
 $input-background-color: $g-light-base4;
 $input-background-color-disabled: $g-light-base4;
 $input-shadow-color-focus: transparent;
-$dark-input-color-disabled: $g-dark-grey3 !default;
+$dark-input-color-disabled: $g-dark-grey2 !default;
 
 $input-box-shadow: 0 0 0 0 transparent;
 $input-box-shadow-focus: 0 0 0 0 transparent;
 $pt-dark-input-box-shadow: 0 0 0 0 transparent;
 
-$input-placeholder-color: $g-light-grey3;
-$dark-input-placeholder-color: $g-dark-grey3;
+$input-placeholder-color: $g-light-grey2;
+$dark-input-placeholder-color: $g-dark-grey2;
 
 // Controls
 $dark-switch-background-color: $dark-gray2;
@@ -33,6 +32,3 @@ $control-background-color-active: $g-light-base4 !default;
 $dark-control-background-color: $g-dark-base4 !default;
 $dark-control-background-color-hover: $g-dark-base4 !default;
 $dark-control-background-color-active: $g-dark-base4 !default;
-
-$pt-divider-black: $g-light-base5;
-$pt-dark-divider-white: $g-dark-base5;

--- a/packages/core/src/components/forms/_overrides.scss
+++ b/packages/core/src/components/forms/_overrides.scss
@@ -239,9 +239,9 @@
 .#{$ns}-input {
     &:disabled {
       &::placeholder {
-        color: $g-light-grey3 !important;
+        color: $g-light-grey2 !important;
         .#{$ns}-dark & {
-          color: $g-dark-grey3 !important;
+          color: $g-dark-grey2 !important;
         }
       }
     }

--- a/packages/core/src/components/menu/_customs.scss
+++ b/packages/core/src/components/menu/_customs.scss
@@ -8,6 +8,3 @@ $menu-item-color-active: $g-light-base5 !important;
 
 $dark-menu-background-color: $g-dark-base3; // Same background as Popover
 $menu-background-color: $g-light-base3;
-
-$pt-icon-color: $g-black;
-$pt-dark-icon-color: $g-white;

--- a/packages/core/src/components/menu/_overrides.scss
+++ b/packages/core/src/components/menu/_overrides.scss
@@ -27,7 +27,7 @@
 }
 
 .#{$ns}-menu-header {
-  color: $g-light-grey2;
+  color: $g-light-grey1;
 
   & > h6 {
     font-size: $pt-font-size-small;
@@ -35,22 +35,22 @@
     font-weight: 400;
     padding-top: 1.5 * $pt-grid-size;
   }
+  &.#{$ns}-disabled {
+    color: $g-light-grey2;
+  }
 }
 
 .#{$ns}-dark {
   .#{$ns}-menu-header {
-    color: $g-dark-grey2;
+    color: $g-dark-grey1;
+  }
+  &.#{$ns}-disabled {
+    color: $g-dark-grey2
   }
 }
 
 .#{$ns}-menu-item-label {
-  color: $g-light-grey1;
+  //color: pt-[dark-]text-muted
   font-size: $pt-font-size-small;
   line-height: $pt-font-size;
-}
-
-.#{$ns}-dark {
-  .#{$ns}-menu-item-label {
-    color: $g-dark-grey1;
-  }
 }

--- a/packages/core/src/components/slider/_overrides.scss
+++ b/packages/core/src/components/slider/_overrides.scss
@@ -43,22 +43,22 @@
 }
 
 .#{$ns}-slider-label {
-  color: $g-light-grey3 !important;
+  color: $g-light-grey2 !important;
 }
 
 .#{$ns}-slider-handle .#{$ns}-slider-label {
-  background-color: $g-light-base0 !important;
+  background-color: $g-light-base1 !important;
   color: $g-black !important;
   border-radius: 4px;
 }
 
 .#{$ns}-dark {
   .#{$ns}-slider-label {
-    color: $g-dark-grey3;
+    color: $g-dark-grey2;
 
   }
   .#{$ns}-slider-handle .#{$ns}-slider-label {
-    background-color: $g-dark-base0 !important;
+    background-color: $g-dark-base1 !important;
     color: $g-white !important;
   }
 }

--- a/packages/core/src/components/tabs/_customs.scss
+++ b/packages/core/src/components/tabs/_customs.scss
@@ -4,13 +4,8 @@ $tab-indicator-width: 2px;
 
 $padding-between-tabs: 16px;
 
-$tab-background-color-dark: #2F4151; //TODO use color variable => base6-dark
-$tab-background-color-light: #F2FAFE; //TODO use color variable => base6-light
+$tab-background-color-dark: $g-dark-base6;
+$tab-background-color-light: $g-light-base6;
 
-$tab-color-disabled-dark: #6A6D74; //TODO use color variable => grey4 dark theme
-$tab-color-disabled-light: #6A6D74; //TODO use color variable => grey1 light theme
-
-$pt-transition-duration: 250ms;
-
-$pt-dark-text-color: $g-white;
-$pt-text-color: $g-black;
+$tab-color-disabled-dark: $g-dark-grey2;
+$tab-color-disabled-light: $g-light-grey2;

--- a/packages/core/src/components/tag-input/_overrides.scss
+++ b/packages/core/src/components/tag-input/_overrides.scss
@@ -7,9 +7,9 @@
     line-height: 16px;
 
     &::placeholder {
-      color: $g-light-grey3 !important;
+      color: $g-light-grey2 !important;
       .#{$ns}-dark & {
-        color: $g-dark-grey3 !important;
+        color: $g-dark-grey2 !important;
       }
     }
   }

--- a/packages/core/src/components/tag/_overrides.scss
+++ b/packages/core/src/components/tag/_overrides.scss
@@ -7,14 +7,14 @@
 }
 
 .#{$ns}-tag {
-  color: $g-light-grey1;
+  color: $g-black;
 
   padding: 4px 8px;
   font-size: $pt-font-size;
 
   // For multiline tags
   >span>p {
-    color: $g-light-grey1;
+    color: $g-black;
     font-size: $pt-font-size-small;
   }
 
@@ -28,11 +28,11 @@
   }
 
   .#{$ns}-dark & {
-    color: $g-dark-grey1;
+    color: $g-white;
 
     // For multiline tags
     >span>p {
-      color: $g-dark-grey1;
+      color: $g-white;
       font-size: $pt-font-size-small;
     }
   }
@@ -53,7 +53,7 @@
     &.#{$ns}-g-disabled {
       cursor: not-allowed;
       background-color: $g-light-base3;
-      color: $g-light-grey3;
+      color: $g-light-grey2;
     }
 
     .#{$ns}-dark & {
@@ -68,7 +68,7 @@
 
       &.#{$ns}-g-disabled {
         background-color: $g-dark-base3;
-        color: $g-dark-grey3;
+        color: $g-dark-grey2;
       }
     }
   }
@@ -91,7 +91,6 @@
     @include custom-lozenge-color('water', $g-water-700, $g-water-200);
     @include custom-lozenge-color('grass', $g-grass-700, $g-grass-200);
     @include custom-lozenge-color('base', $g-black, $g-light-base2);
-    @include custom-lozenge-color('base2', $g-dark-base5, $g-light-base1);
     @include custom-lozenge-color('golden', $g-golden-700, $g-golden-200);
     @include custom-lozenge-color('wood', $g-wood-700, $g-wood-200);
     @include custom-lozenge-color('pacific', $g-pacific-700, $g-pacific-200);
@@ -111,7 +110,6 @@
       @include custom-lozenge-color('water', $g-white, $g-water-600);
       @include custom-lozenge-color('grass', $g-white, $g-grass-600);
       @include custom-lozenge-color('base', $g-white, $g-dark-base2);
-      @include custom-lozenge-color('base2', $g-white, $g-dark-base2);
       @include custom-lozenge-color('golden', $g-white, $g-golden-600);
       @include custom-lozenge-color('wood', $g-white, $g-wood-600);
       @include custom-lozenge-color('pacific', $g-white, $g-pacific-600);
@@ -131,8 +129,7 @@
       @include custom-lozenge-color('error', $g-error-500, $g-error-200);
       @include custom-lozenge-color('water', $g-water-500, $g-water-200);
       @include custom-lozenge-color('grass', $g-grass-500, $g-grass-200);
-      @include custom-lozenge-color('base', $g-light-grey3, $g-light-base3);
-      @include custom-lozenge-color('base2', $g-light-grey4, $g-light-base1);
+      @include custom-lozenge-color('base', $g-light-grey2, $g-light-base3);
       @include custom-lozenge-color('golden', $g-golden-700, $g-golden-200);
       @include custom-lozenge-color('wood', $g-wood-500, $g-wood-200);
       @include custom-lozenge-color('pacific', $g-pacific-500, $g-pacific-200);
@@ -150,8 +147,7 @@
         @include custom-lozenge-color('error', $g-error-700, $g-error-800);
         @include custom-lozenge-color('water', $g-water-700, $g-water-800);
         @include custom-lozenge-color('grass', $g-grass-700, $g-grass-800);
-        @include custom-lozenge-color('base', $g-dark-grey4, $g-dark-base2);
-        @include custom-lozenge-color('base2', $g-dark-grey4, $g-dark-base3);
+        @include custom-lozenge-color('base', $g-dark-grey2, $g-dark-base2);
         @include custom-lozenge-color('golden', $g-golden-700, $g-golden-800);
         @include custom-lozenge-color('wood', $g-wood-700, $g-wood-800);
         @include custom-lozenge-color('pacific', $g-pacific-700, $g-pacific-800);
@@ -174,7 +170,6 @@
         @include custom-lozenge-color('water', $g-water-700, $g-water-100);
         @include custom-lozenge-color('grass', $g-grass-700, $g-grass-100);
         @include custom-lozenge-color('base', $g-black, $g-light-base1);
-        @include custom-lozenge-color('base2', $g-dark-base5, $g-light-base1);
         @include custom-lozenge-color('golden', $g-golden-700, $g-golden-100);
         @include custom-lozenge-color('wood', $g-wood-700, $g-wood-100);
         @include custom-lozenge-color('pacific', $g-pacific-700, $g-pacific-100);
@@ -196,7 +191,6 @@
         @include custom-lozenge-color('water', $g-water-700, $g-water-200, $g-water-700);
         @include custom-lozenge-color('grass', $g-grass-700, $g-grass-200, $g-grass-700);
         @include custom-lozenge-color('base', $g-black, $g-light-base2, $g-black);
-        @include custom-lozenge-color('base2', $g-light-base5, $g-light-base1, $g-light-base5);
         @include custom-lozenge-color('golden', $g-golden-700, $g-golden-200, $g-golden-700);
         @include custom-lozenge-color('wood', $g-wood-700, $g-wood-200, $g-wood-700);
         @include custom-lozenge-color('pacific', $g-pacific-700, $g-pacific-200, $g-pacific-700);
@@ -217,7 +211,6 @@
           @include custom-lozenge-color('water', $g-white, $g-water-500);
           @include custom-lozenge-color('grass', $g-white, $g-grass-500);
           @include custom-lozenge-color('base', $g-white, $g-dark-base3);
-          @include custom-lozenge-color('base2', $g-white, $g-dark-base3);
           @include custom-lozenge-color('golden', $g-white, $g-golden-500);
           @include custom-lozenge-color('wood', $g-white, $g-wood-500);
           @include custom-lozenge-color('pacific', $g-white, $g-pacific-500);
@@ -240,7 +233,6 @@
           @include custom-lozenge-color('water', $g-white, $g-water-600, $g-water-700);
           @include custom-lozenge-color('grass', $g-white, $g-grass-600, $g-grass-700);
           @include custom-lozenge-color('base', $g-white, $g-dark-base2, $g-dark-base3);
-          @include custom-lozenge-color('base2', $g-white, $g-dark-base2, $g-dark-base3);
           @include custom-lozenge-color('golden', $g-white, $g-golden-600, $g-golden-700);
           @include custom-lozenge-color('wood', $g-white, $g-wood-600, $g-wood-700);
           @include custom-lozenge-color('pacific', $g-white, $g-pacific-600, $g-pacific-700);

--- a/packages/select/src/components/select/_overrides.scss
+++ b/packages/select/src/components/select/_overrides.scss
@@ -6,11 +6,6 @@
   margin-top: 0;
 }
 
-.#{$ns}-popover.#{$ns}-dark,
-.#{$ns}-dark .#{$ns}-popover {
-  box-shadow: $custom-shadow;
-}
-
 // MultiSelect
 .#{$ns}-tag-input.#{$ns}-multi-select .#{$ns}-tag-input-values {
   margin-top: 0;


### PR DESCRIPTION
## Update and clean colors
In some components folders, we are using a file called `_customs.scss`, where we overwrite colors. The problem was that some of the variables that were overwritten were used in other components, so you changed a variable in that custom file thinking that it only affected your component, but it was affecting all of them. 

The rule should be: **don't override common variables (such as: `$pt-text-color-muted`) in `_customs` files**. If you want to override a common variable, you should ensure that you are not breaking any other component (these variables are shared) and it should be done in `packages/core/src/common/_customs.scss`.

So in this PR is included the following: 
1. Remove common variables from "_custom" files.
2. Remove unused/old color definitions.
3. Use our new (and reviewed) colors from the DS. The main change here was => Only three grey colors (1, 2, 3). 
