### PR TITLE
fix(Lozenge): check if disabled when interactive to avoid hover effect

### DIFF
--- a/packages/core/src/components/tag/_overrides.scss
+++ b/packages/core/src/components/tag/_overrides.scss
@@ -157,7 +157,7 @@
     }
 
     // Interactive
-    &.#{$ns}-interactive {
+    &.#{$ns}-interactive:not(.#{$ns}-g-disabled) {
       &:hover {
         color: $g-black;
         background-color: $g-light-base5;


### PR DESCRIPTION
## Fix Lozenge interactive & disabled
**Before**

https://github.com/graphext/blueprint/assets/36133677/01a2a778-ce00-4e8a-a17b-346506fa8aca

**After**

https://github.com/graphext/blueprint/assets/36133677/6460ecff-5c66-42d8-a03a-daa0eb8b7394

