### PR TITLE
feat(TablePlot): override table separator color

### DIFF
--- a/packages/core/src/components/html-table/_customs.scss
+++ b/packages/core/src/components/html-table/_customs.scss
@@ -1,0 +1,4 @@
+
+$table-border-color: $g-light-base5;
+$dark-table-border-color: $g-dark-base5;
+

--- a/packages/core/src/components/html-table/_html-table.scss
+++ b/packages/core/src/components/html-table/_html-table.scss
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0.
 
 @import "../../common/variables";
-
+@import "./customs";
 /*
 Tables
 

--- a/packages/core/src/components/html-table/_overrides.scss
+++ b/packages/core/src/components/html-table/_overrides.scss
@@ -7,7 +7,7 @@
 $section-border-width: 2 * $table-border-width;
 
 table.#{$ns}-html-table {
-
+  $table-border-color: $g-light-base5;
   background-color: $g-light-base3;
 
   thead tr {
@@ -90,7 +90,7 @@ table.#{$ns}-html-table {
   }
 
   .#{$ns}-dark & {
-
+    $dark-table-border-color: $g-dark-base5;
     background-color: $g-dark-base3;
 
     /* Add bolder bottom border to thead */

--- a/packages/core/src/components/html-table/_overrides.scss
+++ b/packages/core/src/components/html-table/_overrides.scss
@@ -3,11 +3,11 @@
 
 @import "../../common/variables";
 @import "../../common/_customs";
+@import "./customs";
 
 $section-border-width: 2 * $table-border-width;
 
 table.#{$ns}-html-table {
-  $table-border-color: $g-light-base5;
   background-color: $g-light-base3;
 
   thead tr {
@@ -90,7 +90,6 @@ table.#{$ns}-html-table {
   }
 
   .#{$ns}-dark & {
-    $dark-table-border-color: $g-dark-base5;
     background-color: $g-dark-base3;
 
     /* Add bolder bottom border to thead */


### PR DESCRIPTION
The color of the line separating the header and the body of the table was not the right one, this task fixes that

<img width="404" alt="image" src="https://github.com/graphext/blueprint/assets/36491098/f609bd5c-a225-483d-ba98-7f9c8d8aeee5">
