### PR TITLE
feat(Lozenge): add new kind

### DIFF
--- a/packages/core/src/components/tag/_overrides.scss
+++ b/packages/core/src/components/tag/_overrides.scss
@@ -96,6 +96,7 @@
     @include custom-lozenge-color('pacific', $g-pacific-700, $g-pacific-200);
     @include custom-lozenge-color('graphext', $g-graphext-700, $g-graphext-200);
     @include custom-lozenge-color('highlight', $g-highlight-700, $g-highlight-200);
+    @include custom-lozenge-color('contrasting-base', $g-white, $g-dark-base1);
 
     // Custom kinds dark theme:
     .#{$ns}-dark & {
@@ -115,6 +116,7 @@
       @include custom-lozenge-color('pacific', $g-white, $g-pacific-600);
       @include custom-lozenge-color('graphext', $g-white, $g-graphext-600);
       @include custom-lozenge-color('highlight', $g-white, $g-highlight-600);
+      @include custom-lozenge-color('contrasting-base', $g-black, $g-light-base1);
     }
 
     // Disabled

--- a/packages/core/src/components/tag/_overrides.scss
+++ b/packages/core/src/components/tag/_overrides.scss
@@ -96,7 +96,7 @@
     @include custom-lozenge-color('pacific', $g-pacific-700, $g-pacific-200);
     @include custom-lozenge-color('graphext', $g-graphext-700, $g-graphext-200);
     @include custom-lozenge-color('highlight', $g-highlight-700, $g-highlight-200);
-    @include custom-lozenge-color('contrasting-base', $g-white, $g-dark-base1);
+    @include custom-lozenge-color('contrast-base', $g-white, $g-dark-base1);
 
     // Custom kinds dark theme:
     .#{$ns}-dark & {
@@ -116,7 +116,7 @@
       @include custom-lozenge-color('pacific', $g-white, $g-pacific-600);
       @include custom-lozenge-color('graphext', $g-white, $g-graphext-600);
       @include custom-lozenge-color('highlight', $g-white, $g-highlight-600);
-      @include custom-lozenge-color('contrasting-base', $g-black, $g-light-base1);
+      @include custom-lozenge-color('contrast-base', $g-black, $g-light-base1);
     }
 
     // Disabled


### PR DESCRIPTION
## New lozenge color: 'contrast-base'
![image](https://github.com/graphext/blueprint/assets/36133677/1078c3bd-3a91-4ffa-bd24-9842fe4dc2d0)

I use the word 'contrast' because it uses the base corresponding to the other theme: 
- light: `dark-base1`
- dark: `light-base1`

Used in graphext:
![image](https://github.com/graphext/blueprint/assets/36133677/26e24a8b-426b-4770-967d-030cc7ce1cdb)

