### PR TITLE
Feature/use correct primary color in tab

### DIFF
--- a/packages/core/src/common/_customs.scss
+++ b/packages/core/src/common/_customs.scss
@@ -54,7 +54,7 @@ $g-primary-100: #D5EDFB;
 $g-primary-200: #AADAF6;
 $g-primary-300: #80C8F2;
 $g-primary-400: #55B6ED;
-$g-primary-500: #2BA3E9;
+$g-primary-500: #2BA3E8;
 $g-primary-600: #0091E4;
 $g-primary-700: #006DAB;
 $g-primary-800: #004972;

--- a/packages/core/src/components/tabs/_overrides.scss
+++ b/packages/core/src/components/tabs/_overrides.scss
@@ -152,7 +152,10 @@ $stroke-line-left: inset $tab-indicator-width 0;
       box-shadow: $strokeLinePosition !important;
     }
     &:not([aria-disabled="true"]):not(.#{$ns}-g-tab-disable-hover-effect):hover {
-      box-shadow: $strokeLinePosition $pt-intent-primary !important;
+      box-shadow: $strokeLinePosition $g-light-active-hover !important;
+      .#{$ns}-dark & {
+        box-shadow: $strokeLinePosition $g-dark-active-hover !important;
+      }
     }
   }
 }


### PR DESCRIPTION
This color (line when active + hover) was not correct
![image](https://github.com/graphext/blueprint/assets/36133677/893f9dbc-b59f-484d-8fda-23394e1b889e)
