### PR TITLE
ci: publish preview versions for PR branches

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -88,15 +88,13 @@ steps:
       - echo -n $NPMRC | base64 -d > /root/.npmrc
       - |
         set -e
-        echo "=== Env vars (CI/WOODPECKER/DRONE) ==="
-        env | grep -iE '^(CI_|WOODPECKER_|DRONE_)' | sort
-        echo "=== ==="
-        SHA=$(echo $CI_COMMIT_SHA | cut -c1-7)
-        [ -z "$SHA" ] && SHA=$(echo $WOODPECKER_COMMIT_SHA | cut -c1-7)
-        [ -z "$SHA" ] && SHA=$(echo $CI_COMMIT_PULL_REQUEST_SHA | cut -c1-7)
+        SHA=$(echo "${CI_COMMIT_SHA}" | cut -c1-7)
         PR_TAG="pr-${CI_COMMIT_PULL_REQUEST}"
         echo "Preview build for PR #${CI_COMMIT_PULL_REQUEST}, SHA=${SHA}"
-        [ -z "$SHA" ] && { echo "FATAL: no SHA variable found"; exit 1; }
+        if [ -z "$SHA" ]; then
+          echo "FATAL: CI_COMMIT_SHA not set"
+          exit 1
+        fi
 
         for pkg in icons core select datetime datetime2 table; do
           node -e "

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -88,9 +88,15 @@ steps:
       - echo -n $NPMRC | base64 -d > /root/.npmrc
       - |
         set -e
+        echo "=== Env vars (CI/WOODPECKER/DRONE) ==="
+        env | grep -iE '^(CI_|WOODPECKER_|DRONE_)' | sort
+        echo "=== ==="
         SHA=$(echo $CI_COMMIT_SHA | cut -c1-7)
+        [ -z "$SHA" ] && SHA=$(echo $WOODPECKER_COMMIT_SHA | cut -c1-7)
+        [ -z "$SHA" ] && SHA=$(echo $CI_COMMIT_PULL_REQUEST_SHA | cut -c1-7)
         PR_TAG="pr-${CI_COMMIT_PULL_REQUEST}"
-        echo "Preview build for PR #${CI_COMMIT_PULL_REQUEST}, SHA ${SHA}"
+        echo "Preview build for PR #${CI_COMMIT_PULL_REQUEST}, SHA=${SHA}"
+        [ -z "$SHA" ] && { echo "FATAL: no SHA variable found"; exit 1; }
 
         for pkg in icons core select datetime datetime2 table; do
           node -e "

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -90,8 +90,8 @@ steps:
         set -e
         SHA=$(echo "${CI_COMMIT_SHA}" | cut -c1-7)
         PR_TAG="pr-${CI_COMMIT_PULL_REQUEST}"
-        echo "Preview build for PR #${CI_COMMIT_PULL_REQUEST}, SHA=${SHA}"
-        if [ -z "$SHA" ]; then
+        echo "Preview build for PR #${CI_COMMIT_PULL_REQUEST}, SHA=$$SHA"
+        if [ -z "$$SHA" ]; then
           echo "FATAL: CI_COMMIT_SHA not set"
           exit 1
         fi
@@ -99,9 +99,9 @@ steps:
         for pkg in icons core select datetime datetime2 table; do
           node -e "
             const fs = require('fs');
-            const p = './packages/$pkg/package.json';
+            const p = './packages/$$pkg/package.json';
             const j = JSON.parse(fs.readFileSync(p));
-            j.version = j.version + '-preview.${SHA}';
+            j.version = j.version + '-preview.' + '$$SHA';
             fs.writeFileSync(p, JSON.stringify(j, null, 4) + '\n');
           "
         done
@@ -111,29 +111,29 @@ steps:
         published=0
         failed=0
         for pkg in icons core select datetime datetime2 table; do
-          if out=$(npm publish ./packages/$pkg --tag $PR_TAG 2>&1); then
-            echo "$out"
+          if out=$(npm publish ./packages/$$pkg --tag $$PR_TAG 2>&1); then
+            echo "$$out"
             published=$((published + 1))
           else
-            echo "$out"
-            if echo "$out" | grep -q "already exists"; then
-              echo ">>> skip $pkg (version already published)"
+            echo "$$out"
+            if echo "$$out" | grep -q "already exists"; then
+              echo ">>> skip $$pkg (version already published)"
             else
               failed=$((failed + 1))
             fi
           fi
         done
 
-        if [ "$failed" -gt 0 ]; then
-          echo "ERROR: $failed package(s) failed to publish"
+        if [ "$$failed" -gt 0 ]; then
+          echo "ERROR: $$failed package(s) failed to publish"
           exit 1
         fi
-        if [ "$published" -eq 0 ]; then
+        if [ "$$published" -eq 0 ]; then
           echo "ERROR: nothing was published"
           exit 1
         fi
-        echo "Published $published package(s) under dist-tag '$PR_TAG'"
-        echo "To consume: npm install @blueprintjs/<pkg>@$PR_TAG"
+        echo "Published $$published package(s) under dist-tag $$PR_TAG"
+        echo "To consume: npm install @blueprintjs/<pkg>@$$PR_TAG"
       - rm /root/.npmrc
     environment:
       NPMRC:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -2,8 +2,9 @@ labels:
   hostname: secondary-rwo
 
 when:
-  event: push
-  branch: deploy
+  - event: push
+    branch: deploy
+  - event: pull_request
 
 variables:
   - &node_image node:20-alpine
@@ -37,6 +38,9 @@ steps:
     <<: *default_backend_options
 
   - name: publish
+    when:
+      event: push
+      branch: deploy
     image: *node_image
     commands:
       - apk add --update-cache git openssh
@@ -75,7 +79,64 @@ steps:
       - build
     <<: *default_backend_options
 
+  - name: publish-preview
+    when:
+      event: pull_request
+    image: *node_image
+    commands:
+      - apk add --update-cache git openssh
+      - echo -n $NPMRC | base64 -d > /root/.npmrc
+      - SHA=$(echo $CI_COMMIT_SHA | cut -c1-7)
+      - PR_TAG="pr-${CI_COMMIT_PULL_REQUEST}"
+      - |
+        for pkg in icons core select datetime datetime2 table; do
+          node -e "
+            const fs = require('fs');
+            const p = './packages/$pkg/package.json';
+            const j = JSON.parse(fs.readFileSync(p));
+            j.version = j.version + '-preview.${SHA}';
+            fs.writeFileSync(p, JSON.stringify(j, null, 4) + '\n');
+          "
+        done
+      - node scripts/resolveWorkspaceRefs.js
+      - |
+        published=0
+        failed=0
+        for pkg in icons core select datetime datetime2 table; do
+          if out=$(npm publish ./packages/$pkg --tag $PR_TAG 2>&1); then
+            echo "$out"
+            published=$((published + 1))
+          else
+            echo "$out"
+            if echo "$out" | grep -q "already exists"; then
+              echo ">>> skip $pkg (version already published)"
+            else
+              failed=$((failed + 1))
+            fi
+          fi
+        done
+        if [ "$failed" -gt 0 ]; then
+          echo "ERROR: $failed package(s) failed to publish"
+          exit 1
+        fi
+        if [ "$published" -eq 0 ]; then
+          echo "ERROR: nothing was published"
+          exit 1
+        fi
+        echo "Published $published package(s) under dist-tag '$PR_TAG'"
+        echo "To consume: npm install @blueprintjs/<pkg>@$PR_TAG"
+      - rm /root/.npmrc
+    environment:
+      NPMRC:
+        from_secret: NPMRC_GAR_CI_PRIVATE
+    depends_on:
+      - build
+    <<: *default_backend_options
+
   - name: docs
+    when:
+      event: push
+      branch: deploy
     image: *node_image
     commands:
       - apk add --update-cache git openssh

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -86,9 +86,12 @@ steps:
     commands:
       - apk add --update-cache git openssh
       - echo -n $NPMRC | base64 -d > /root/.npmrc
-      - SHA=$(echo $CI_COMMIT_SHA | cut -c1-7)
-      - PR_TAG="pr-${CI_COMMIT_PULL_REQUEST}"
       - |
+        set -e
+        SHA=$(echo $CI_COMMIT_SHA | cut -c1-7)
+        PR_TAG="pr-${CI_COMMIT_PULL_REQUEST}"
+        echo "Preview build for PR #${CI_COMMIT_PULL_REQUEST}, SHA ${SHA}"
+
         for pkg in icons core select datetime datetime2 table; do
           node -e "
             const fs = require('fs');
@@ -98,8 +101,9 @@ steps:
             fs.writeFileSync(p, JSON.stringify(j, null, 4) + '\n');
           "
         done
-      - node scripts/resolveWorkspaceRefs.js
-      - |
+
+        node scripts/resolveWorkspaceRefs.js
+
         published=0
         failed=0
         for pkg in icons core select datetime datetime2 table; do
@@ -115,6 +119,7 @@ steps:
             fi
           fi
         done
+
         if [ "$failed" -gt 0 ]; then
           echo "ERROR: $failed package(s) failed to publish"
           exit 1


### PR DESCRIPTION
## Summary

Adds a `publish-preview` step in `.woodpecker.yml` that runs on `pull_request` events. It:

1. Bumps each publishable package version with a `-preview.<sha7>` suffix (e.g. `5.19.1-graphext52-preview.abc1234`).
2. Resolves `workspace:^` refs against the bumped versions so inter-package deps point to the matching preview.
3. Publishes each package under dist-tag `pr-<PR_NUMBER>`, NOT touching `latest`.

Consumers can then test PR builds with:
```bash
npm install @blueprintjs/core@pr-<N>
# or pin to specific SHA:
npm install @blueprintjs/core@5.19.1-graphext52-preview.abc1234
```

## Behaviour changes in `.woodpecker.yml`

- Top-level `when:` now accepts both `push:deploy` and `pull_request`.
- `publish` step gained an explicit `when: { event: push, branch: deploy }` (no behavioural change).
- `docs` step gained an explicit `when: { event: push, branch: deploy }` (no behavioural change).
- New `publish-preview` step gated to `pull_request`.

## Prerequisites

The `NPMRC_GAR_CI_PRIVATE` secret in Woodpecker must allow `pull_request` events (off by default). This needs to be toggled in the Woodpecker UI before the new step can succeed.

## Test plan

- [ ] This PR itself triggers `publish-preview` (meta-test). Should publish `@blueprintjs/*@pr-<this-PR-num>`.
- [ ] Verify with `npm view @blueprintjs/core dist-tags` that `latest` is unchanged.
- [ ] Try `npm install @blueprintjs/core@pr-<N>` from the graphext app to confirm consumption works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)