### PR TITLE
docs: modernize GRAPHEXT_README (pnpm/Node24) + document fork upgrade strategy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,10 @@
 # Blueprint.js Agentic Development Guide
 
+> **This is the Graphext fork of Palantir's Blueprint.** Before any upstream version bump, fork
+> publish, or `-graphextNN` version change, read [`GRAPHEXT_README.md`](GRAPHEXT_README.md) — it
+> documents the upstream-sync strategy (squash upstream, never squash the PR), the version suffix
+> scheme, the styles-only rule, and how publishing works (push to `deploy`).
+
 ## Build/Test Commands
 
 - **Build**: `pnpm compile` (all packages), `pnpm nx compile @blueprintjs/core` (single package)

--- a/GRAPHEXT_README.md
+++ b/GRAPHEXT_README.md
@@ -1,132 +1,192 @@
 # Blueprint Graphext fork
-Before starting developing, please see "One-time setup" section in [Readme](README.md) file.
+
+This is a fork of [Palantir's Blueprint library](https://github.com/palantir/blueprint) for React UI
+components. The main branch of this repository is `graphext`; publishing happens from `deploy`.
+
+> **Toolchain:** pnpm `10.33.0` + Node `>=24.14.1` (pinned via `packageManager` / `engines` in
+> `package.json`, enabled through `corepack`). The repo migrated off yarn + `docker-compose run bp`
+> during the BP6 upgrade — run the pnpm scripts directly.
+>
+> **Day-to-day commands** (compile, test, lint, dist, single-package targets) live in
+> [`AGENTS.md`](AGENTS.md). This file documents the *fork-specific* concerns: syncing with upstream,
+> the version suffix scheme, and how to publish.
 
 ## How to sync with upstream
-This is a fork of [Palantir's blueprint library](https://github.com/palantir/blueprint) for React UI components, and the main branch of this repository is `graphext`.
-We should always pull commits of a completed released version of blueprint.
-- If the latest commit of `develop` branch is the last of the desired release, we can retrieve the changes from `upstream develop` into a new branch in `origin`:
-```
-git checkout updateUpstream && git pull upstream develop
-```
-- Otherwise, the *pull* must be done from the release's specific commit.
-- Push all incoming commits to the branch created in `origin`.
-- Prepare a Pull Request to `origin graphext`.
-- Note that all commits coming from upstream must be **squashed** into one.
 
-## If Blueprint package version change
-If Blueprint package version change (for example from 3.53.0 to 4.0.0) is **needed to remove "-graphext[OldVersion]"** from all the package.json . This is made in order to get the first install and compile of the packages:
+We should always pull commits of a **completed released version** of Blueprint (a tag like
+`@blueprintjs/core@X.Y.Z`), never an arbitrary `develop` commit.
+
+1. Retrieve the upstream changes into a new branch in `origin`:
+   ```bash
+   git checkout -b updateUpstream-X.Y.Z origin/graphext
+   git pull upstream develop          # or `git merge <release-tag>` if develop has moved past it
+   ```
+2. **Squash all commits coming from upstream into a single commit** (e.g.
+   `chore: merge upstream Blueprint X.Y.Z (squashed)`). The fork deliberately does **not** track
+   upstream's git ancestry — see *A bit of history* below for why real merges were abandoned.
+3. Re-apply the Graphext adaptation layer **as separate, well-labelled commits on top** of that one
+   squashed commit (see *Updating Blueprint styles*). Keeping the boundary "1 upstream-import commit
+   ↔ N Graphext commits" sharp is what makes the *next* upgrade easy: the next person can see at a
+   glance which commits/files are ours to carry forward.
+4. Open a Pull Request against `origin/graphext`.
+
+### Merge strategy for the PR — this matters
+
+- ✅ **Rebase-and-merge** (or a merge commit). Preserves the labelled commits and the
+  upstream-vs-Graphext boundary.
+- ❌ **Never "Squash and merge" the whole PR.** It collapses the upstream import together with every
+  Graphext adaptation into one commit, destroying exactly the boundary that keeps future upgrades
+  cheap.
+
+## Version suffix scheme (`-graphextNN`)
+
+Published packages carry a `-graphextNN` suffix on top of the upstream semver, e.g.
+`@blueprintjs/core@6.15.0-graphext53`. The suffix is bumped on every Graphext-side change.
+
+On a **major upstream version change** (e.g. 5.x → 6.x) you must temporarily **remove the
+`-graphext[OldVersion]` suffix** from every `packages/*/package.json` so the first install/compile
+resolves real upstream versions:
+
+```bash
+pnpm install
+pnpm compile
+pnpm dist
 ```
-docker-compose run bp sh -c 'yarn && yarn compile'
-```
-Once it's done, we can create de dist files with:
-```
-docker-compose run bp sh -c 'yarn dist:libs'
-```
-Then **change the package names to "-graphext[NewVersion]" again** directly in each `packages/*/package.json`. Woodpecker CI will publish on push to `deploy`.
-Otherwise, we will be assembling the package by downloading an older version of blueprint and it will not be compatible with our environment.
+
+Then **re-add the `-graphext[NewVersion]` suffix** in each `packages/*/package.json`. Otherwise the
+build assembles against an older published Blueprint and won't be compatible with our environment.
 
 ## Updating Blueprint styles
-The purpose of this repository is to adapt blueprint UI components' styles to Graphext design, then, it is forbidden to update blueprint javascript. Graphext developers must only update blueprint styles. To do that, the steps to follow must be:
-- Blueprint uses `!default` flag at the end of some `scss` variable declarations. Therefore, graphext developers must see if they can use `scss` variables in order to get the desired style.
-- If the first approach cannot be done, then the developer must add the `scss` styles to `_overrides.scss` files stayed in `packages/core` and `packages/select`.
 
-  Note that many Blueprint components are built using other Blueprint components. Then, it is important that style overwriting be done by using specific classnames.
+The purpose of this fork is to adapt Blueprint components' styles to the Graphext design. **Do not
+modify Blueprint JavaScript** — Graphext developers should only change styles:
 
-The following packages of this monorepo have been already updated by Graphext and they are already published in graphext npm registry:
-    - `core`
-    - `datetime`
-    - `select`
-    - `icons`
-    - `table`
-    - `popover2`
+- Blueprint declares many `scss` variables with a `!default` flag, so prefer overriding those
+  variables to get the desired look.
+- When that isn't enough, add the overrides to the `_overrides.scss` files in `packages/core` and
+  `packages/select`, and (since BP6) to the **CSS-vars bridge** introduced in the 6.15 upgrade that
+  re-maps BP6 design tokens back to the BP5 visual baseline.
+
+  Many Blueprint components are composed from other Blueprint components, so scope overrides with
+  specific classnames.
+
+The packages Graphext customizes and publishes to the registry (matching the `publish` step in
+`.woodpecker.yml`) are:
+
+- `core`
+- `icons`
+- `select`
+- `datetime`
+- `datetime2`
+- `table`
 
 ## How to publish the changes
 
-In the top directory you can compile all the packages
-```
-docker-compose run bp yarn compile
-```
-And then create the bundles with
-```
-docker-compose run bp yarn dist:libs
-```
-After that you can upgrade the version of the changed packages adding +1 after the `graphext` part of the version directly in each `packages/*/package.json`. Take into account the dependencies between packages, like the icons --> core dependency.
-
-Woodpecker CI handles publishing automatically on push to `deploy` branch.
+1. Compile and build the bundles:
+   ```bash
+   pnpm compile
+   pnpm dist
+   ```
+2. Bump the `-graphextNN` suffix of the changed packages in each `packages/*/package.json`. Mind the
+   inter-package dependencies (e.g. `icons → core`).
+3. **Merge `graphext` into `deploy`.** Woodpecker CI (`.woodpecker.yml`) publishes the packages to the
+   private registry (GAR) and deploys the docs on every push to `deploy`.
 
 ## How to add new icons
 
-The icon generator script is [`generate-icons-source.js`](packages/node-build-scripts/generate-icons-source.js). This script uses [`packages/icons/resources/icons/icons.json` ](packages/icons/resources/icons/icons.json) as entry, which is the file we have to modify in order to add a new icon.
-- 1. Add a new object at the end of the other Graphext components:
+The icon generator script is
+[`generate-icons-source.js`](packages/node-build-scripts/generate-icons-source.js). It reads
+[`packages/icons/resources/icons/icons.json`](packages/icons/resources/icons/icons.json), which is the
+file to edit when adding a new icon.
 
-```
-    ...
-    , {
-        "displayName": "The Paco",
-        "iconName": "paco",
-        "tags": "hombre, mozo, machote",
-        "group": "Graphext",
-        "codepoint":  99999
-    },
-    ...
-```
-- `iconName` is the most important parameter. It has to resemble the svg filename, choose a good one because it is also the name that must be used in the code to use this icon.
-- `tags` is just useful to search icons in the documentation.
-- `group` is only used in the documentation too. We must add all icons to **Graphext** group to see all icons added by graphext together.
-- `codepoint` must be **unique** number. This number must be **unique** in the file. (Search before commit) One way of selecting a name is using https://unicode-table.com/ Search for the concept you want to add and copy the number.
-- Add `svg` resources in the following folders
-    - `resources/icons/16px`
-    - `resources/icons/20px`
-
-  We can add the same `svg` in both folders, but could be nicer to generate one for 16px and another one for 20px.
-- Finally, icons must be compiled, open a new terminal and paste:
-```
-docker-compose run bp yarn --cwd packages/icons compile
-```
-- Check the results: the fastest way is running the core and the documentation
-```
-docker-compose run bp yarn dev:core
-```
+1. Add a new object at the end of the other Graphext components:
+   ```json
+       , {
+           "displayName": "The Paco",
+           "iconName": "paco",
+           "tags": "hombre, mozo, machote",
+           "group": "Graphext",
+           "codepoint":  99999
+       }
+   ```
+   - `iconName` is the most important parameter. It must resemble the SVG filename — choose well, it is
+     also the name used in code to reference the icon.
+   - `tags` only helps searching icons in the documentation.
+   - `group` is documentation-only. Add all icons to the **Graphext** group so they appear together.
+   - `codepoint` must be a **unique** number in the file (search before committing).
+2. Add the `svg` resources to both `resources/icons/16px` and `resources/icons/20px` (the same SVG
+   works in both, though a 16px-tuned variant is nicer).
+3. Compile the icons:
+   ```bash
+   pnpm nx compile @blueprintjs/icons
+   ```
+4. Check the result by running core + docs:
+   ```bash
+   pnpm dev:core
+   ```
 
 ## A bit of history about this repository...
-### How we included the changes from palantir blueprint
-A long time ago, we did a fork from the blueprint repository. We kept adding functionality in the `graphext` branch,
-and when we wanted to deploy it, we merge it into `deploy` branch.
-But time goes, and we realized it would be nice if we can have all the changes that the blueprint team had added,
-and we were missing since the fork. As you may be thinking...yes, that merge was a bit scary.
 
-We tried to merge the branch from palantir in our graphext branch, but a lot of changes arise, a lot of them because of format changes...
-so we thought the best solution was to say goodbye to our beloved `graphext` branch and its history and just add our changes into their branch.
-This meant that we were going to lose all our commit history (bye-bye to git blame!), so we copied `graphext` into `graphextOld`.
-So if you want to see the rationality behind a change, you may need to check it [there](https://github.com/graphext/blueprint/tree/graphextOld).
+### How we included the changes from Palantir Blueprint
+
+A long time ago we forked the Blueprint repository. We kept adding functionality in the `graphext`
+branch, and when we wanted to deploy it we merged it into `deploy`.
+
+Over time we wanted all the changes the Blueprint team had added since the fork. As you may be
+thinking... yes, that merge was a bit scary. We tried to merge Palantir's branch into our `graphext`
+branch and a lot of changes arose, many because of format changes — so we decided to say goodbye to
+our beloved `graphext` branch and its history and just add our changes on top of theirs. This meant
+losing our commit history (bye-bye `git blame`!), so we copied `graphext` into `graphextOld`. If you
+want the rationale behind an old change, check
+[there](https://github.com/graphext/blueprint/tree/graphextOld).
 
 Just to be clear:
-- we copied `graphext` branch into `graphextOld`
+
+- we copied `graphext` into `graphextOld`
 - we removed `graphext`
 - we created `graphext` again from `palantir:develop`
-- we [merged](https://github.com/graphext/blueprint/tree/e64b857881ab2c310600c567635f3b753e6f03e6) `graphextOld` into our new `graphext` branch
+- we [merged](https://github.com/graphext/blueprint/tree/e64b857881ab2c310600c567635f3b753e6f03e6)
+  `graphextOld` into the new `graphext` branch
 
-We were facing a similar situation with the `deploy` branch, and the process was as follows:
-- we copied `deploy` branch into `deployOld`
-- we removed `graphext`
+We faced a similar situation with `deploy`:
+
+- we copied `deploy` into `deployOld`
+- we removed `deploy`
 - we created `deploy` again from `graphext`
 
-Oh, wait! And what happened with the changes in the `deploy` branch? Were they lost?
-Yes, but it doesn't matter because `deploy` should reflect `graphext` history branch. It is just a new beginning.
-The [first version](https://npm.graphext.com/-/web/detail/@blueprintjs/core/v/3.53.0-graphext01]) that included those changes was `3.53.0-graphex01`.
+What happened to the changes in `deploy`? They were lost, but it doesn't matter because `deploy`
+should just reflect `graphext`'s history — a fresh start. The
+[first version](https://npm.graphext.com/-/web/detail/@blueprintjs/core/v/3.53.0-graphext01) that
+included those changes was `3.53.0-graphext01`.
 
-This is how we included the changes from palantir in our repository.
-At this point, we were able to work as we used to do (PR in `graphext` and then if you want to deploy your changes, merge it into `deploy`).
+This is how we included Palantir's changes. After this we were able to work as usual (PR into
+`graphext`, then merge into `deploy` to publish).
 
 ### v5 upgrade
-I recommend checking both PRs, where we explained how it went:
+
+Worth reading both PRs, where the process is explained:
+
 - [Blueprint](https://github.com/graphext/blueprint/pull/107)
 - [Graphext](https://github.com/graphext/graphext/pull/2745)
 
-## Developing with Graphext, Storybook and Blueprint:
+### v6 upgrade (5.19.1 → 6.15.0)
 
-There are some special commands on `docker-compose.yml` created to work easier with Graphext, Storybook and Blueprint.
-There is more information about it on **WORKING WITH 🔵 BLUEPRINT** section of [Storybook readme.](https://pre.graphext.com/storybook/?path=/story/design-system-how-to-use--page)
+[Blueprint PR #134](https://github.com/graphext/blueprint/pull/134). Approach, which is the template
+for future upgrades:
 
-## Warning:
-**DO NOT USE the `%` on CSS Opacity because it breaks on Graphext build**, use instead `opacity: 0.5;` for example.
+- Upstream Blueprint `6.8.0` was brought in **squashed into one commit**, then bumped `6.8 → 6.15`.
+- The Graphext visual baseline (BP5.19.1 styling) was preserved with a new **CSS-vars bridge** plus
+  the existing `_overrides.scss`, validated against BP5.19.1 ↔ BP6.15 visual-parity fixtures.
+- The toolchain migrated from **yarn → pnpm** and **Node 20 → Node 24**, and CI was reworked
+  (`build` on all branches, `publish`/`docs` restricted to `deploy`, preview publishes on PRs).
+- Published as `@blueprintjs/*@6.x-graphext53`.
+
+## Developing with Graphext, Storybook and Blueprint
+
+There are some special commands in `docker-compose.yml` to make working with Graphext, Storybook and
+Blueprint easier. More info in the **WORKING WITH 🔵 BLUEPRINT** section of the
+[Storybook readme](https://pre.graphext.com/storybook/?path=/story/design-system-how-to-use--page).
+
+## Warning
+
+**DO NOT use `%` on CSS opacity — it breaks the Graphext build.** Use `opacity: 0.5;` instead.


### PR DESCRIPTION
Follow-up to #134 (BP6.15 upgrade). The fork docs were stale (yarn + `docker-compose run bp`, popover2 in the published list, no upgrade playbook).

## What changed
- **`GRAPHEXT_README.md`**
  - Replace yarn / `docker-compose run bp` with the current pnpm scripts; note the pnpm 10.33 + Node 24 toolchain.
  - Fix the published-packages list to match `.woodpecker.yml`: `core, icons, select, datetime, datetime2, table` (drop `popover2`).
  - Document the upstream-sync **merge strategy** explicitly: squash upstream into one commit, layer Graphext adaptations as separate labelled commits, **rebase/merge-commit the PR — never squash the whole PR** (that destroys the upstream-vs-Graphext boundary that keeps future upgrades cheap).
  - Add a **v6 upgrade (5.19.1 → 6.15.0)** history entry as the template for the next bump.
  - Point day-to-day commands to `AGENTS.md`.
- **`AGENTS.md`**: prominent pointer to `GRAPHEXT_README.md` for fork-specific concerns.

Docs-only, no code/build impact.