### PR TITLE
chore: declare React 19 compatibility (widen peer deps to "18 || 19")

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,9 +60,9 @@
         "tslib": "catalog:"
     },
     "peerDependencies": {
-        "@types/react": "18",
-        "react": "18",
-        "react-dom": "18"
+        "@types/react": "18 || 19",
+        "react": "18 || 19",
+        "react-dom": "18 || 19"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -48,9 +48,9 @@
         "tslib": "catalog:"
     },
     "peerDependencies": {
-        "@types/react": "18",
-        "react": "18",
-        "react-dom": "18"
+        "@types/react": "18 || 19",
+        "react": "18 || 19",
+        "react-dom": "18 || 19"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/datetime2/package.json
+++ b/packages/datetime2/package.json
@@ -42,9 +42,9 @@
         "tslib": "catalog:"
     },
     "peerDependencies": {
-        "@types/react": "18",
-        "react": "18",
-        "react-dom": "18"
+        "@types/react": "18 || 19",
+        "react": "18 || 19",
+        "react-dom": "18 || 19"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/docs-theme/package.json
+++ b/packages/docs-theme/package.json
@@ -43,9 +43,9 @@
         "tslib": "catalog:"
     },
     "peerDependencies": {
-        "@types/react": "18",
-        "react": "18",
-        "react-dom": "18"
+        "@types/react": "18 || 19",
+        "react": "18 || 19",
+        "react-dom": "18 || 19"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -49,9 +49,9 @@
         "tslib": "catalog:"
     },
     "peerDependencies": {
-        "@types/react": "18",
-        "react": "18",
-        "react-dom": "18"
+        "@types/react": "18 || 19",
+        "react": "18 || 19",
+        "react-dom": "18 || 19"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/labs/package.json
+++ b/packages/labs/package.json
@@ -33,9 +33,9 @@
         "tslib": "catalog:"
     },
     "peerDependencies": {
-        "@types/react": "18",
-        "react": "18",
-        "react-dom": "18"
+        "@types/react": "18 || 19",
+        "react": "18 || 19",
+        "react-dom": "18 || 19"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -44,9 +44,9 @@
         "tslib": "catalog:"
     },
     "peerDependencies": {
-        "@types/react": "18",
-        "react": "18",
-        "react-dom": "18"
+        "@types/react": "18 || 19",
+        "react": "18 || 19",
+        "react-dom": "18 || 19"
     },
     "peerDependenciesMeta": {
         "@types/react": {

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -44,9 +44,9 @@
         "tslib": "catalog:"
     },
     "peerDependencies": {
-        "@types/react": "18",
-        "react": "18",
-        "react-dom": "18"
+        "@types/react": "18 || 19",
+        "react": "18 || 19",
+        "react-dom": "18 || 19"
     },
     "peerDependenciesMeta": {
         "@types/react": {


### PR DESCRIPTION
## What

Widen the `react` / `react-dom` / `@types/react` peer dependency ranges from `"18"` to `"18 || 19"` across all published packages: **core, datetime, datetime2, docs-theme, icons, labs, select, table**. (`test-commons` already uses `>=16.8` and is not published.)

This declares React 19 compatibility for the Graphext Blueprint fork. It mirrors upstream palantir/blueprint [#8147](https://github.com/palantir/blueprint/pull/8147), which shipped in `@blueprintjs/core@6.16.0` — our fork sits exactly one upstream minor behind the React 19 release.

## Why this is the only change needed

Review of the fork (currently `graphext` @ core 6.15.0-graphext53) found **no React 19 blockers**:

- **No `findDOMNode`** in source (only a comment in `overlay2.tsx`; overlay2 already uses the `nodeRef`/CSSTransition pattern built for React 18+/StrictMode).
- **No `ReactDOM.render` / `unmountComponentAtNode`.**
- **`defaultProps` only on class components** (DateRangePicker, DateRangeInput, Suggest, etc.) — still valid in React 19; only function-component defaultProps are ignored.
- All internal components (Tooltip, Select, MultiSelect, Suggest, DateInput, ContextMenuPopover, Menu submenus, Breadcrumbs) already route through **`PopoverNext`** (Floating UI), which is React-19-safe.

### The legacy `<Popover>` caveat (not an issue here)

The only React-19-incompatible path is the deprecated react-popper `<Popover>`, which mis-positions under React 19 (worst in StrictMode). It has **no internal consumers** in BP6, and Graphext app code imports it in **0 files**. Upstream's other two React 19 commits (#8149 dev-warn on legacy Popover, #8162 a tooltip hover-target ref fix) are deliberately **not** included — the warn would never fire for us, and the tooltip fix is an independent regression fix best handled separately.

## Verification

- `pnpm install` — no lockfile changes (dev deps stay on React 18; the range only declares compatibility).
- `pnpm compile` — passes (exit 0).
- Prettier format-check — passes.
- Functional React 19 validation happens in the consuming app when Graphext bumps React.

🤖 Generated with [Claude Code](https://claude.com/claude-code)