### PR TITLE
chore: backport upstream React 19 follow-ups (#8162 Tooltip fix, #8149 legacy Popover warn)

### DIFF
--- a/packages/core/src/common/errors.ts
+++ b/packages/core/src/common/errors.ts
@@ -83,6 +83,9 @@ export const POPOVER_WARN_PLACEMENT_AND_POSITION_MUTEX =
 export const POPOVER_WARN_UNCONTROLLED_ONINTERACTION = ns + ` <Popover> onInteraction is ignored when uncontrolled.`;
 export const POPOVER_WARN_TARGET_PROPS_WITH_RENDER_TARGET =
     ns + ` <Popover> targetProps value is ignored when renderTarget API is used.`;
+export const POPOVER_WARN_REACT19 =
+    ns +
+    ` <Popover> positions content incorrectly under React 19 (especially in StrictMode); migrate to <PopoverNext>.`;
 
 export const RADIOGROUP_WARN_CHILDREN_OPTIONS_MUTEX =
     ns + ` <RadioGroup> children and options prop are mutually exclusive, with options taking priority.`;

--- a/packages/core/src/common/utils/jsUtils.ts
+++ b/packages/core/src/common/utils/jsUtils.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { version } from "react";
+
 import { CLAMP_MIN_MAX } from "../errors";
 
 // injected by webpack.DefinePlugin
@@ -23,6 +25,14 @@ declare let NODE_ENV: string;
 /** Returns whether bundler-injected variable `NODE_ENV` equals `env`. */
 export function isNodeEnv(env: string) {
     return typeof NODE_ENV !== "undefined" && NODE_ENV === env;
+}
+
+/**
+ * Returns the major version of the running React runtime as an integer
+ * (e.g. "19.1.0" -> 19, "18.3.1" -> 18).
+ */
+export function getReactMajorVersion(): number {
+    return parseInt(version, 10);
 }
 
 /**

--- a/packages/core/src/components/popover-next/popoverNext.test.tsx
+++ b/packages/core/src/components/popover-next/popoverNext.test.tsx
@@ -8,7 +8,7 @@ import { createRef } from "react";
 
 import { afterAll, beforeEach, describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
-import { Classes } from "../../common";
+import { Classes, mergeRefs } from "../../common";
 import * as Errors from "../../common/errors";
 import { Button, Dialog, DialogBody, InputGroup, PopupKind, Tooltip } from "../../components";
 import type { PopoverInteractionKind } from "../popover/popoverProps";
@@ -1245,6 +1245,34 @@ describe("<PopoverNext>", () => {
             expect(screen.queryByText("tooltip content")).not.toBeInTheDocument();
         });
 
+        it("opens popover when Tooltip renderTarget props are spread after PopoverNext renderTarget props", async () => {
+            const user = userEvent.setup();
+            render(
+                <PopoverNext
+                    content="popover content"
+                    renderTarget={({ isOpen: isPopoverOpen, ref: popoverRef, ...popoverProps }) => (
+                        <Tooltip
+                            content="tooltip content"
+                            disabled={isPopoverOpen}
+                            renderTarget={({ isOpen: _isTooltipOpen, ref: tooltipRef, ...tooltipProps }) => (
+                                <Button
+                                    {...popoverProps}
+                                    {...tooltipProps}
+                                    active={isPopoverOpen}
+                                    ref={mergeRefs(popoverRef, tooltipRef)}
+                                    text="target"
+                                />
+                            )}
+                        />
+                    )}
+                />,
+            );
+
+            await user.click(screen.getByRole("button", { name: "target" }));
+
+            await waitFor(() => expect(screen.getByText("popover content")).toBeInTheDocument());
+        });
+
         it("the target is focusable", () => {
             render(
                 <PopoverNext content="popover content">
@@ -1669,6 +1697,32 @@ describe("<PopoverNext>", () => {
                     )}
                 />,
             );
+        });
+    });
+
+    describe("renderTarget interaction props", () => {
+        it.each(["click", "click-target"] as const)("injects onClick into renderTarget props for %s", kind => {
+            const renderTarget = vi.fn(({ isOpen: _isOpen, ref, ...props }) => (
+                <Button ref={ref} text="target" {...props} />
+            ));
+            render(<PopoverNext content="content" interactionKind={kind} renderTarget={renderTarget} />);
+
+            expect(renderTarget).toHaveBeenCalled();
+            expect(typeof renderTarget.mock.calls[0][0].onClick).toBe("function");
+        });
+
+        // Hover popovers (and Tooltip, which is always hover) open via mouseenter/focus, never click, so
+        // their target must not receive an onClick. Injecting one shadows a consumer's own onClick when a
+        // hover target is shared with an enclosing Popover via renderTarget. See usePopover's useClick and
+        // PopoverTarget's floatingReferenceProps.
+        it.each(["hover", "hover-target"] as const)("does not inject onClick into renderTarget props for %s", kind => {
+            const renderTarget = vi.fn(({ isOpen: _isOpen, ref, ...props }) => (
+                <Button ref={ref} text="target" {...props} />
+            ));
+            render(<PopoverNext content="content" interactionKind={kind} renderTarget={renderTarget} />);
+
+            expect(renderTarget).toHaveBeenCalled();
+            expect(renderTarget.mock.calls[0][0].onClick).toBeUndefined();
         });
     });
 });

--- a/packages/core/src/components/popover-next/popoverNext.tsx
+++ b/packages/core/src/components/popover-next/popoverNext.tsx
@@ -105,6 +105,10 @@ export const PopoverNext = forwardRef<PopoverNextRef, PopoverNextProps>((props, 
 
     const computedIsOpen = disabled ? false : (isOpen ?? defaultIsOpen);
 
+    const isHoverInteractionKind =
+        interactionKind === PopoverInteractionKind.HOVER ||
+        interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY;
+
     const middleware = useMemo(() => {
         const defaultMiddleware: MiddlewareConfig = {
             ...(placement === undefined
@@ -135,6 +139,7 @@ export const PopoverNext = forwardRef<PopoverNextRef, PopoverNextProps>((props, 
         autoUpdateOptions,
         disabled,
         isControlled,
+        isHoverInteractionKind,
         isOpen: computedIsOpen,
         middleware,
         onOpenChange: (nextOpen, event) => {
@@ -156,10 +161,6 @@ export const PopoverNext = forwardRef<PopoverNextRef, PopoverNextProps>((props, 
     );
 
     const popoverElement = floatingData.refs.floating.current;
-
-    const isHoverInteractionKind =
-        interactionKind === PopoverInteractionKind.HOVER ||
-        interactionKind === PopoverInteractionKind.HOVER_TARGET_ONLY;
 
     const getPopoverElement = useCallback(() => {
         return popoverElement?.querySelector<HTMLElement>(`.${Classes.POPOVER}`);

--- a/packages/core/src/components/popover-next/popoverTarget.tsx
+++ b/packages/core/src/components/popover-next/popoverTarget.tsx
@@ -88,6 +88,17 @@ export const PopoverTarget = forwardRef<HTMLElement, PopoverTargetProps>((props,
     // Ensure target is focusable if relevant prop enabled
     const targetTabIndex = !isContentEmpty && !disabled && openOnTargetFocus && isHoverInteractionKind ? 0 : undefined;
 
+    // Hover targets (including Tooltip) open via the mouse/focus handlers in `targetEventHandlers`, so
+    // they must not receive Floating UI's reference props; those carry the `onClick`/keyboard click
+    // handlers used for click interactions. Applying them to a hover target injects an `onClick` that
+    // can shadow a consumer's own handler when the target is shared with an enclosing Popover via
+    // `renderTarget`. This mirrors legacy `Popover`, which only attached click handlers for click kinds.
+    const floatingProps = isHoverInteractionKind
+        ? {}
+        : floatingData.getReferenceProps({
+              onKeyDown: handleReferenceKeyDown,
+          });
+
     const ownTargetProps = {
         // N.B. this.props.className is passed along to renderTarget even though the user would have access to it.
         // If, instead, renderTarget is undefined and the target is provided as a child, props.className is
@@ -118,10 +129,6 @@ export const PopoverTarget = forwardRef<HTMLElement, PopoverTargetProps>((props,
     let target: React.JSX.Element | undefined;
 
     if (renderTarget !== undefined) {
-        const floatingProps = floatingData.getReferenceProps({
-            onKeyDown: handleReferenceKeyDown,
-        });
-
         // When using renderTarget, if the consumer renders a tooltip target, it's their responsibility
         // to disable that tooltip when this popover is open
         target = renderTarget({
@@ -152,9 +159,7 @@ export const PopoverTarget = forwardRef<HTMLElement, PopoverTargetProps>((props,
                 ...ownTargetProps,
                 ...targetProps,
                 // Apply Floating UI's interaction props to the wrapper element (same element that has the ref)
-                ...floatingData.getReferenceProps({
-                    onKeyDown: handleReferenceKeyDown,
-                }),
+                ...floatingProps,
             },
             clonedTarget,
         );

--- a/packages/core/src/components/popover-next/usePopover.ts
+++ b/packages/core/src/components/popover-next/usePopover.ts
@@ -22,6 +22,7 @@ interface PopoverOptions {
     autoUpdateOptions?: PopoverNextAutoUpdateOptions;
     disabled?: boolean;
     isControlled?: boolean;
+    isHoverInteractionKind?: boolean;
     isOpen?: boolean;
     middleware?: Middleware[];
     placement?: Placement;
@@ -38,6 +39,7 @@ export function usePopover({
     autoUpdateOptions,
     disabled = false,
     isControlled = false,
+    isHoverInteractionKind = false,
     isOpen = false,
     middleware,
     placement,
@@ -94,7 +96,7 @@ export function usePopover({
     const { context } = data;
 
     const click = useClick(context, {
-        enabled: !disabled,
+        enabled: !disabled && !isHoverInteractionKind,
         // Disable Floating UI's built-in Space/Enter keyboard handlers because they
         // call `preventDefault()` on the Space keydown event to prevent page scrolling.
         // This also prevents space characters from being typed in <input>/<textarea>

--- a/packages/core/src/components/popover/popover.test.tsx
+++ b/packages/core/src/components/popover/popover.test.tsx
@@ -19,6 +19,7 @@ import userEvent from "@testing-library/user-event";
 
 import {
     afterAll,
+    afterEach,
     beforeAll,
     beforeEach,
     describe,
@@ -31,6 +32,7 @@ import {
 import { Button, PopupKind, Tooltip } from "..";
 import { Classes } from "../../common";
 import * as Errors from "../../common/errors";
+import * as Utils from "../../common/utils";
 
 import { Popover } from "./popover";
 import { type PopoverInteractionKind } from "./popoverProps";
@@ -135,6 +137,32 @@ describe("<Popover>", () => {
                     expect(warnSpy).toHaveBeenCalledWith(Errors.POPOVER_HAS_BACKDROP_INTERACTION);
                 });
             }
+        });
+    });
+
+    describe("React 19 deprecation warning", () => {
+        afterEach(() => vi.restoreAllMocks());
+
+        it("does not warn on React < 19", () => {
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
+            vi.spyOn(Utils, "getReactMajorVersion").mockReturnValue(18);
+            render(
+                <Popover content="hello">
+                    <button>target</button>
+                </Popover>,
+            );
+            expect(warnSpy).not.toHaveBeenCalledWith(Errors.POPOVER_WARN_REACT19);
+        });
+
+        it("warns once on React 19", () => {
+            const warnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
+            vi.spyOn(Utils, "getReactMajorVersion").mockReturnValue(19);
+            render(
+                <Popover content="hello">
+                    <button>target</button>
+                </Popover>,
+            );
+            expect(warnSpy).toHaveBeenCalledWith(Errors.POPOVER_WARN_REACT19);
         });
     });
 

--- a/packages/core/src/components/popover/popover.tsx
+++ b/packages/core/src/components/popover/popover.tsx
@@ -137,6 +137,9 @@ export class Popover<
     // element on the same page.
     private lostFocusOnSamePage = true;
 
+    // Ensures the React 19 incompatibility warning fires at most once per instance.
+    private didWarnReact19 = false;
+
     // Reference to the Poppper.scheduleUpdate() function, this changes every time the popper is mounted
     private popperScheduleUpdate?: () => Promise<Partial<PopperState> | null>;
 
@@ -200,6 +203,19 @@ export class Popover<
 
     public componentDidMount() {
         this.updateDarkParent();
+        this.warnIfReact19();
+    }
+
+    /**
+     * Dev-only: warn that this deprecated component's react-popper dependency silently mis-positions
+     * content under React 19 (worst under StrictMode). Steers consumers to PopoverNext.
+     */
+    private warnIfReact19() {
+        if (this.didWarnReact19 || Utils.isNodeEnv("production") || Utils.getReactMajorVersion() < 19) {
+            return;
+        }
+        this.didWarnReact19 = true;
+        console.warn(Errors.POPOVER_WARN_REACT19);
     }
 
     public componentDidUpdate(props: PopoverProps<T>, state: PopoverState) {

--- a/packages/core/src/components/tooltip/tooltip.test.tsx
+++ b/packages/core/src/components/tooltip/tooltip.test.tsx
@@ -20,7 +20,8 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "@blueprintjs/test-commons/vitest";
 
 import { Button } from "..";
-import { Classes } from "../../common";
+import { Classes, mergeRefs } from "../../common";
+import { PopoverNext } from "../popover-next/popoverNext";
 
 import { Tooltip } from "./tooltip";
 
@@ -75,6 +76,23 @@ describe("<Tooltip>", () => {
             expect(
                 container.querySelector(`.${Classes.TOOLTIP}.${Classes.POPOVER_MINIMAL_ANIMATION}`),
             ).not.toBeInTheDocument();
+        });
+
+        it("does not inject click handlers into renderTarget props", () => {
+            let targetProps: Partial<React.HTMLProps<HTMLElement>> | undefined;
+
+            render(
+                <Tooltip
+                    content="content"
+                    renderTarget={({ isOpen: _isOpen, ref, ...props }) => {
+                        targetProps = props;
+                        return <Button {...props} ref={ref} text="target" />;
+                    }}
+                />,
+            );
+
+            expect(targetProps?.onClick).toBeUndefined();
+            expect(targetProps?.onKeyDown).toBeUndefined();
         });
     });
 
@@ -299,5 +317,37 @@ describe("<Tooltip>", () => {
         await user.keyboard("{Escape}");
 
         await waitFor(() => expect(screen.queryByText("first tooltip")).not.toBeInTheDocument());
+    });
+
+    // Regression test: a Tooltip nested inside a click Popover, both rendering a single shared target via
+    // `renderTarget`. Because Tooltip is hover-only, it must not inject an `onClick` into its target props;
+    // otherwise it would shadow the enclosing Popover's `onClick` and the target click would not open the
+    // Popover. The popover's props are spread first and the tooltip's second, the order that broke before.
+    it("does not inject an onClick that shadows an enclosing Popover's target onClick", async () => {
+        const user = userEvent.setup();
+        render(
+            <PopoverNext
+                content={<div>popover content</div>}
+                hoverOpenDelay={0}
+                renderTarget={({ isOpen: _isPopoverOpen, ref: popoverRef, ...popoverProps }) => (
+                    <Tooltip
+                        content="tooltip content"
+                        hoverOpenDelay={0}
+                        renderTarget={({ isOpen: _isTooltipOpen, ref: tooltipRef, ...tooltipProps }) => (
+                            <Button
+                                {...popoverProps}
+                                {...tooltipProps}
+                                ref={mergeRefs(popoverRef, tooltipRef)}
+                                text="target"
+                            />
+                        )}
+                    />
+                )}
+            />,
+        );
+
+        await user.click(screen.getByText("target"));
+
+        await waitFor(() => expect(screen.getByText("popover content")).toBeInTheDocument());
     });
 });


### PR DESCRIPTION
Backports the two remaining React-19 commits from upstream palantir/blueprint `@blueprintjs/core@6.16.0` (the peer-dep widening, #8147, was already landed as our `-graphext54` release in #137). Both cherry-picked cleanly onto `graphext` (BP6 6.15.0) with `-x`.

## Commits

- **`#8162` [core] Fix Tooltip renderTarget click handler regression** — hover targets (incl. Tooltip) no longer receive Floating UI's reference props (which carry the click/keyboard handlers); applying them to a hover target could inject an `onClick` that shadows a consumer's own handler when the target is shared with an enclosing Popover via `renderTarget`. **Real fix, relevant here** — graphext uses `<Tooltip>` in ~38 files and all BP6 internals route through `PopoverNext`.
- **`#8149` [core] Warn on legacy Popover usage under React 19** — dev-only `console.warn` that the deprecated react-popper `<Popover>` mis-positions under React 19 (worst in StrictMode), steering to `<PopoverNext>`. Adds `getReactMajorVersion()` + `POPOVER_WARN_REACT19`. Zero prod cost; never fires for graphext (0 legacy `<Popover>` usages) but gives parity with upstream 6.16.0 and helps other fork consumers (e.g. gatekeeper).

## Notes

- No version bump in this PR — suffix bump to `-graphext55` + merge to `deploy` (publish) will be a follow-up once reviewed.
- The fork's CI does not run Blueprint's own Karma/Mocha suite; the included `.test.tsx` changes come along for parity and are validated by the build step only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)