### PR TITLE
chore: add Apache-2.0 modification NOTICE to published packages

### DIFF
--- a/packages/core/NOTICE
+++ b/packages/core/NOTICE
@@ -1,0 +1,17 @@
+Blueprint
+
+Copyright Palantir Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License"); see the
+accompanying LICENSE file or http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+MODIFICATIONS
+
+This package is a MODIFIED version of Blueprint, maintained by Graphext as a
+fork of the upstream Palantir Blueprint library
+(https://github.com/palantir/blueprint). Graphext builds are published from
+https://github.com/graphext/blueprint under version tags carrying a
+"-graphextNN" suffix. Modifications are Copyright Graphext and are likewise
+licensed under the Apache License, Version 2.0. See the fork's commit history
+for the specific changes.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@blueprintjs/core",
-    "version": "6.15.0-graphext55",
+    "version": "6.15.0-graphext56",
     "description": "Core styles & components",
     "main": "lib/cjs/index.js",
     "module": "lib/esm/index.js",
@@ -10,7 +10,8 @@
     "files": [
         "lib",
         "scripts",
-        "src"
+        "src",
+        "NOTICE"
     ],
     "sideEffects": [
         "**/*.css",

--- a/packages/datetime/NOTICE
+++ b/packages/datetime/NOTICE
@@ -1,0 +1,17 @@
+Blueprint
+
+Copyright Palantir Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License"); see the
+accompanying LICENSE file or http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+MODIFICATIONS
+
+This package is a MODIFIED version of Blueprint, maintained by Graphext as a
+fork of the upstream Palantir Blueprint library
+(https://github.com/palantir/blueprint). Graphext builds are published from
+https://github.com/graphext/blueprint under version tags carrying a
+"-graphextNN" suffix. Modifications are Copyright Graphext and are likewise
+licensed under the Apache License, Version 2.0. See the fork's commit history
+for the specific changes.

--- a/packages/datetime/package.json
+++ b/packages/datetime/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@blueprintjs/datetime",
-    "version": "6.1.1-graphext55",
+    "version": "6.1.1-graphext56",
     "description": "Components for interacting with dates and times",
     "main": "lib/cjs/index.js",
     "module": "lib/esm/index.js",
@@ -9,7 +9,8 @@
     "style": "lib/css/blueprint-datetime.css",
     "files": [
         "lib",
-        "src"
+        "src",
+        "NOTICE"
     ],
     "sideEffects": [
         "**/*.css"

--- a/packages/datetime2/NOTICE
+++ b/packages/datetime2/NOTICE
@@ -1,0 +1,17 @@
+Blueprint
+
+Copyright Palantir Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License"); see the
+accompanying LICENSE file or http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+MODIFICATIONS
+
+This package is a MODIFIED version of Blueprint, maintained by Graphext as a
+fork of the upstream Palantir Blueprint library
+(https://github.com/palantir/blueprint). Graphext builds are published from
+https://github.com/graphext/blueprint under version tags carrying a
+"-graphextNN" suffix. Modifications are Copyright Graphext and are likewise
+licensed under the Apache License, Version 2.0. See the fork's commit history
+for the specific changes.

--- a/packages/datetime2/package.json
+++ b/packages/datetime2/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@blueprintjs/datetime2",
-    "version": "3.1.1-graphext55",
+    "version": "3.1.1-graphext56",
     "description": "Re-exports of @blueprintjs/datetime APIs",
     "main": "lib/cjs/index.js",
     "module": "lib/esm/index.js",
@@ -12,7 +12,8 @@
     ],
     "files": [
         "lib",
-        "src"
+        "src",
+        "NOTICE"
     ],
     "scripts": {
         "clean": "rm -rf coverage lib",

--- a/packages/icons/NOTICE
+++ b/packages/icons/NOTICE
@@ -1,0 +1,17 @@
+Blueprint
+
+Copyright Palantir Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License"); see the
+accompanying LICENSE file or http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+MODIFICATIONS
+
+This package is a MODIFIED version of Blueprint, maintained by Graphext as a
+fork of the upstream Palantir Blueprint library
+(https://github.com/palantir/blueprint). Graphext builds are published from
+https://github.com/graphext/blueprint under version tags carrying a
+"-graphextNN" suffix. Modifications are Copyright Graphext and are likewise
+licensed under the Apache License, Version 2.0. See the fork's commit history
+for the specific changes.

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@blueprintjs/icons",
-    "version": "6.10.0-graphext55",
+    "version": "6.10.0-graphext56",
     "description": "Components, fonts, icons, and css files for creating and displaying icons.",
     "main": "lib/cjs/generated/index.js",
     "module": "lib/esm/generated/index.js",
@@ -10,7 +10,8 @@
     "files": [
         "lib",
         "src",
-        "icons.json"
+        "icons.json",
+        "NOTICE"
     ],
     "sideEffects": [
         "**/*.css"

--- a/packages/select/NOTICE
+++ b/packages/select/NOTICE
@@ -1,0 +1,17 @@
+Blueprint
+
+Copyright Palantir Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License"); see the
+accompanying LICENSE file or http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+MODIFICATIONS
+
+This package is a MODIFIED version of Blueprint, maintained by Graphext as a
+fork of the upstream Palantir Blueprint library
+(https://github.com/palantir/blueprint). Graphext builds are published from
+https://github.com/graphext/blueprint under version tags carrying a
+"-graphextNN" suffix. Modifications are Copyright Graphext and are likewise
+licensed under the Apache License, Version 2.0. See the fork's commit history
+for the specific changes.

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@blueprintjs/select",
-    "version": "6.2.1-graphext55",
+    "version": "6.2.1-graphext56",
     "description": "Components related to selecting items from a list",
     "main": "lib/cjs/index.js",
     "module": "lib/esm/index.js",
@@ -9,7 +9,8 @@
     "style": "lib/css/blueprint-select.css",
     "files": [
         "lib",
-        "src"
+        "src",
+        "NOTICE"
     ],
     "sideEffects": [
         "**/*.css"

--- a/packages/table/NOTICE
+++ b/packages/table/NOTICE
@@ -1,0 +1,17 @@
+Blueprint
+
+Copyright Palantir Technologies, Inc.
+Licensed under the Apache License, Version 2.0 (the "License"); see the
+accompanying LICENSE file or http://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+MODIFICATIONS
+
+This package is a MODIFIED version of Blueprint, maintained by Graphext as a
+fork of the upstream Palantir Blueprint library
+(https://github.com/palantir/blueprint). Graphext builds are published from
+https://github.com/graphext/blueprint under version tags carrying a
+"-graphextNN" suffix. Modifications are Copyright Graphext and are likewise
+licensed under the Apache License, Version 2.0. See the fork's commit history
+for the specific changes.

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@blueprintjs/table",
-    "version": "6.1.1-graphext55",
+    "version": "6.1.1-graphext56",
     "description": "Scalable interactive table component",
     "main": "lib/cjs/index.js",
     "module": "lib/esm/index.js",
@@ -9,7 +9,8 @@
     "style": "lib/css/table.css",
     "files": [
         "lib",
-        "src"
+        "src",
+        "NOTICE"
     ],
     "sideEffects": [
         "**/*.css"


### PR DESCRIPTION
## Why

Blueprint is a **modified fork** of Palantir's Apache-2.0 library, shipped inside Graphext frontend bundles (gatekeeper, graphext). Because the browser downloads and runs that JS, we are **distributing a modified Apache-2.0 work**, which triggers Apache-2.0 **§4.2** — *modified files must carry prominent notices stating that we changed them*.

Today the only in-artifact signal is the `-graphextNN` version suffix (too weak to count), and `GRAPHEXT_README.md` is **not** in any package's `files` array, so no modification statement travels with the published npm package.

## What

Add an identical `NOTICE` file (exact filename, **no extension**) to each of the **6 published packages**, and list `"NOTICE"` in each package's `files` array so npm packs it (npm auto-includes `LICENSE`/`README` but **not** `NOTICE`).

| Package | version bump |
|---|---|
| `@blueprintjs/core` | `6.15.0-graphext55` → `-graphext56` |
| `@blueprintjs/icons` | `6.10.0-graphext55` → `-graphext56` |
| `@blueprintjs/select` | `6.2.1-graphext55` → `-graphext56` |
| `@blueprintjs/datetime` | `6.1.1-graphext55` → `-graphext56` |
| `@blueprintjs/datetime2` | `3.1.1-graphext55` → `-graphext56` |
| `@blueprintjs/table` | `6.1.1-graphext55` → `-graphext56` |

Scope = exactly the packages the `.woodpecker.yml` publish step ships. `colors`, `docs-theme` and the tooling packages are **not** published from this fork, so they are intentionally out of scope.

## Auto-propagation downstream

Consumers reproduce the NOTICE automatically — no per-consumer code change:
- CycloneDX evidence collection (`collectEvidence: true`) matches the filename regex `^NOTICE$` (anchored → **must** be exactly `NOTICE`, not `.md`/`.txt`).
- The consumer `licenses.rake` concatenates all evidence files per component into `public/licenses.html`.

## Verification

- `npm pack --dry-run` on each of the 6 lists `740B NOTICE` in the tarball, next to `LICENSE`.
- `prettier --check` passes on all 6 changed `package.json`.
- Filenames are exactly `NOTICE` (no extension).

Follow-up (separate PRs): bump `@blueprintjs/*` to `-graphext56` in graphext and gatekeeper, then confirm the notice reaches `licenses.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FgW6GazA1Lg4LLjzQ8PH4M